### PR TITLE
#22 docs: add stability policy and semver guarantees

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 
 SPDX-License-Identifier: MIT
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: 2025 RA <contact@revaprogramm.com>
+SPDX-FileCopyrightText: 2025-2026 RA <contact@revaprogramm.com>
 SPDX-License-Identifier: MIT
 -->
 

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -1,0 +1,164 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Stability Policy
+
+This document describes the stability guarantees for `entity-derive` and how
+semantic versioning is applied to the crate.
+
+## Versioning
+
+This crate follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+- **MAJOR** (1.0.0 → 2.0.0): Breaking changes to stable APIs
+- **MINOR** (1.0.0 → 1.1.0): New features, backward-compatible
+- **PATCH** (1.0.0 → 1.0.1): Bug fixes, backward-compatible
+
+### Pre-1.0 Policy
+
+While the crate is below version 1.0.0:
+
+- **MINOR** bumps may include breaking changes
+- **PATCH** bumps are always backward-compatible
+- Breaking changes are documented in CHANGELOG.md
+
+## Stable Guarantees
+
+The following are considered stable and follow semver:
+
+### Attribute Syntax
+
+```rust
+#[derive(Entity)]
+#[entity(table = "...", schema = "...", sql = "...", dialect = "...", uuid = "...")]
+pub struct Entity {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response, skip)]
+    pub field: T,
+
+    #[auto]
+    pub timestamp: DateTime<Utc>,
+}
+```
+
+Attribute names and their accepted values are stable. New attributes may be
+added in minor versions but existing attributes will not change behavior.
+
+### Generated Type Names
+
+For an entity `User`, these type names are stable:
+
+| Type | Name Pattern |
+|------|--------------|
+| Create DTO | `Create{Name}Request` |
+| Update DTO | `Update{Name}Request` |
+| Response DTO | `{Name}Response` |
+| Repository trait | `{Name}Repository` |
+| Row struct | `{Name}Row` |
+| Insertable struct | `Insertable{Name}` |
+
+### Repository Trait Methods
+
+The following trait methods and their signatures are stable:
+
+```rust
+trait {Name}Repository: Send + Sync {
+    type Error: std::error::Error + Send + Sync;
+    type Pool;
+
+    fn pool(&self) -> &Self::Pool;
+    async fn create(&self, dto: Create{Name}Request) -> Result<{Name}, Self::Error>;
+    async fn find_by_id(&self, id: IdType) -> Result<Option<{Name}>, Self::Error>;
+    async fn update(&self, id: IdType, dto: Update{Name}Request) -> Result<{Name}, Self::Error>;
+    async fn delete(&self, id: IdType) -> Result<bool, Self::Error>;
+    async fn list(&self, limit: i64, offset: i64) -> Result<Vec<{Name}>, Self::Error>;
+}
+```
+
+### DTO Structure
+
+- `CreateRequest` includes fields marked with `#[field(create)]`
+- `UpdateRequest` includes fields marked with `#[field(update)]`, wrapped in `Option<T>`
+- `Response` includes fields marked with `#[field(response)]` and `#[id]`
+- All DTOs derive `Debug`, `Clone`, `Serialize`, `Deserialize`
+
+### Feature Flags
+
+These feature flags are stable:
+
+| Flag | Purpose |
+|------|---------|
+| `postgres` | PostgreSQL support via sqlx |
+| `api` | OpenAPI schema generation (utoipa) |
+| `validate` | Validation derive (validator) |
+
+## Unstable / Experimental
+
+The following may change without a major version bump:
+
+### Generated SQL
+
+The exact SQL queries generated are not part of the public API. While they
+will remain functionally equivalent, the specific query text may change.
+
+### Internal Modules
+
+Anything under `entity::parse` is internal and may change. Only re-exported
+types in the public API are stable.
+
+### Planned Features (Not Yet Stable)
+
+These features are planned but not yet implemented:
+
+- `clickhouse` dialect
+- `mongodb` dialect
+- Relations (`#[belongs_to]`, `#[has_many]`)
+- Soft delete (`#[soft_delete]`)
+- Lifecycle hooks
+
+### Generated Code Internals
+
+- Helper structs and their internal fields
+- Implementation details of `From` conversions
+- Order of generated items
+
+## What Constitutes a Breaking Change
+
+### Breaking (requires MAJOR bump post-1.0)
+
+- Removing or renaming attributes
+- Changing attribute behavior
+- Removing generated types or methods
+- Changing method signatures in generated traits
+- Removing feature flags
+
+### Not Breaking (allowed in MINOR/PATCH)
+
+- Adding new attributes
+- Adding new methods to generated traits (with default impls)
+- Adding new feature flags
+- Changing generated SQL (if functionally equivalent)
+- Performance improvements
+- Bug fixes that correct clearly wrong behavior
+- Adding new derive macros to generated types
+
+## Minimum Supported Rust Version (MSRV)
+
+- Current MSRV: **1.92.0**
+- MSRV bumps are considered breaking changes pre-1.0
+- Post-1.0, MSRV bumps require at least a minor version bump
+
+## Reporting Issues
+
+If you believe a change violated this policy, please open an issue with:
+
+1. Version before and after the change
+2. Code that worked before but broke after
+3. Expected vs actual behavior
+
+We take backward compatibility seriously and will issue patch releases to
+fix accidental breakage.

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 
 [changelog]
 header = """
 <!--
-SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 
 SPDX-License-Identifier: MIT
 -->

--- a/deny.toml
+++ b/deny.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/src/entity.rs
+++ b/src/entity.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Entity derive macro implementation.

--- a/src/entity/dto.rs
+++ b/src/entity/dto.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Data Transfer Object (DTO) generation.

--- a/src/entity/insertable.rs
+++ b/src/entity/insertable.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Insertable struct generation for INSERT operations.

--- a/src/entity/mappers.rs
+++ b/src/entity/mappers.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Type mapper generation for entity conversions.

--- a/src/entity/parse.rs
+++ b/src/entity/parse.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Attribute parsing for the Entity derive macro.

--- a/src/entity/parse/dialect.rs
+++ b/src/entity/parse/dialect.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Database dialect configuration.

--- a/src/entity/parse/entity.rs
+++ b/src/entity/parse/entity.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Entity-level attribute parsing.

--- a/src/entity/parse/field.rs
+++ b/src/entity/parse/field.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Field-level attribute parsing.

--- a/src/entity/parse/field/expose.rs
+++ b/src/entity/parse/field/expose.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! DTO exposure configuration for entity fields.

--- a/src/entity/parse/field/storage.rs
+++ b/src/entity/parse/field/storage.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Database storage configuration for entity fields.

--- a/src/entity/parse/sql_level.rs
+++ b/src/entity/parse/sql_level.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! SQL generation level configuration.

--- a/src/entity/parse/uuid_version.rs
+++ b/src/entity/parse/uuid_version.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! UUID version configuration for ID generation.

--- a/src/entity/repository.rs
+++ b/src/entity/repository.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Repository trait generation.

--- a/src/entity/row.rs
+++ b/src/entity/row.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Database row struct generation.

--- a/src/entity/sql.rs
+++ b/src/entity/sql.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! SQL implementation generation for the Entity derive macro.

--- a/src/entity/sql/clickhouse.rs
+++ b/src/entity/sql/clickhouse.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! ClickHouse implementation for repository code generation.

--- a/src/entity/sql/mongodb.rs
+++ b/src/entity/sql/mongodb.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! MongoDB implementation for repository code generation.

--- a/src/entity/sql/postgres.rs
+++ b/src/entity/sql/postgres.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! PostgreSQL repository implementation generator.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #![doc = include_str!("../README.md")]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Shared utilities for code generation.

--- a/src/utils/fields.rs
+++ b/src/utils/fields.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Field assignment generation for `From` implementations.

--- a/src/utils/marker.rs
+++ b/src/utils/marker.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Generated code marker utilities.

--- a/src/utils/sql.rs
+++ b/src/utils/sql.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! SQL query building utilities.

--- a/tests/cases/fail/clickhouse_not_implemented.rs
+++ b/tests/cases/fail/clickhouse_not_implemented.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/fail/enum_derive.rs
+++ b/tests/cases/fail/enum_derive.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/fail/missing_table.rs
+++ b/tests/cases/fail/missing_table.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/fail/mongodb_not_implemented.rs
+++ b/tests/cases/fail/mongodb_not_implemented.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/fail/tuple_struct.rs
+++ b/tests/cases/fail/tuple_struct.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/fail/unit_struct.rs
+++ b/tests/cases/fail/unit_struct.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/pass/all_field_attrs.rs
+++ b/tests/cases/pass/all_field_attrs.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/pass/basic_entity.rs
+++ b/tests/cases/pass/basic_entity.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/pass/custom_error.rs
+++ b/tests/cases/pass/custom_error.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Test custom error type support.

--- a/tests/cases/pass/no_create_fields.rs
+++ b/tests/cases/pass/no_create_fields.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Entity with no create fields - only ID and response fields.

--- a/tests/cases/pass/no_update_fields.rs
+++ b/tests/cases/pass/no_update_fields.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Entity with only response fields - no create or update.

--- a/tests/cases/pass/sql_none.rs
+++ b/tests/cases/pass/sql_none.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/pass/sql_trait_only.rs
+++ b/tests/cases/pass/sql_trait_only.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 use entity_derive::Entity;

--- a/tests/cases/pass/uuid_v4.rs
+++ b/tests/cases/pass/uuid_v4.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 //! Test UUID v4 generation option.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 // SPDX-License-Identifier: MIT
 
 #[test]


### PR DESCRIPTION
## Summary

Add STABILITY.md documenting semantic versioning policy and stability guarantees.

## Contents

- Versioning policy (pre-1.0 and post-1.0)
- Stable guarantees: attributes, type names, trait methods, DTO structure, feature flags
- Unstable/experimental: SQL internals, planned features, internal modules
- Breaking vs non-breaking changes
- MSRV policy

Closes #22