### PR TITLE
#8 feat: add entity projections for partial selects

### DIFF
--- a/src/entity.rs
+++ b/src/entity.rs
@@ -58,6 +58,7 @@ mod dto;
 mod insertable;
 mod mappers;
 pub mod parse;
+mod projection;
 mod repository;
 mod row;
 mod sql;
@@ -80,6 +81,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
 fn generate(entity: EntityDef) -> TokenStream {
     let dto = dto::generate(&entity);
+    let projections = projection::generate(&entity);
     let repository = repository::generate(&entity);
     let row = row::generate(&entity);
     let insertable = insertable::generate(&entity);
@@ -88,6 +90,7 @@ fn generate(entity: EntityDef) -> TokenStream {
 
     let expanded = quote! {
         #dto
+        #projections
         #repository
         #row
         #insertable

--- a/src/entity/parse.rs
+++ b/src/entity/parse.rs
@@ -104,7 +104,7 @@ mod sql_level;
 mod uuid_version;
 
 pub use dialect::DatabaseDialect;
-pub use entity::EntityDef;
+pub use entity::{EntityDef, ProjectionDef};
 pub use field::FieldDef;
 pub use sql_level::SqlLevel;
 pub use uuid_version::UuidVersion;

--- a/src/entity/projection.rs
+++ b/src/entity/projection.rs
@@ -1,0 +1,123 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Projection struct generation.
+//!
+//! This module generates projection structs for partial entity views.
+//! Each projection defines a subset of fields for specific use cases:
+//!
+//! | Projection | Use Case |
+//! |------------|----------|
+//! | `UserPublic` | Public profile (id, name, avatar) |
+//! | `UserAdmin` | Admin view (id, name, email, role) |
+//! | `PostSummary` | List view (id, title, created_at) |
+//!
+//! # Definition
+//!
+//! Projections are defined at entity level:
+//!
+//! ```rust,ignore
+//! #[derive(Entity)]
+//! #[entity(table = "users")]
+//! #[projection(Public: id, name, avatar)]
+//! #[projection(Admin: id, name, email, role)]
+//! pub struct User { ... }
+//! ```
+//!
+//! # Generated Code
+//!
+//! For each projection, generates:
+//! - `{Entity}{Projection}` struct with specified fields
+//! - `From<{Entity}> for {Entity}{Projection}` implementation
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use super::parse::EntityDef;
+use crate::utils::marker;
+
+/// Generates all projection structs for the entity.
+///
+/// Returns a combined `TokenStream` containing projection struct definitions
+/// and their From implementations.
+pub fn generate(entity: &EntityDef) -> TokenStream {
+    let projections: Vec<TokenStream> = entity
+        .projections
+        .iter()
+        .map(|proj| generate_projection(entity, proj))
+        .collect();
+
+    quote! { #(#projections)* }
+}
+
+/// Generate a single projection struct and its From impl.
+fn generate_projection(entity: &EntityDef, proj: &super::parse::ProjectionDef) -> TokenStream {
+    let vis = &entity.vis;
+    let entity_name = entity.name();
+    let proj_name = format_ident!("{}{}", entity_name, proj.name);
+
+    let field_defs: Vec<TokenStream> = proj
+        .fields
+        .iter()
+        .filter_map(|field_name| {
+            entity
+                .fields
+                .iter()
+                .find(|f| f.name() == field_name)
+                .map(|f| {
+                    let n = f.name();
+                    let t = f.ty();
+                    quote! { pub #n: #t }
+                })
+        })
+        .collect();
+
+    if field_defs.is_empty() {
+        return TokenStream::new();
+    }
+
+    let field_mappings: Vec<TokenStream> = proj
+        .fields
+        .iter()
+        .filter_map(|field_name| {
+            entity
+                .fields
+                .iter()
+                .find(|f| f.name() == field_name)
+                .map(|f| {
+                    let n = f.name();
+                    quote! { #n: value.#n.clone() }
+                })
+        })
+        .collect();
+
+    let marker = marker::generated();
+
+    quote! {
+        #marker
+        #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+        #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+        #[cfg_attr(feature = "postgres", derive(sqlx::FromRow))]
+        #vis struct #proj_name {
+            #(#field_defs),*
+        }
+
+        #marker
+        impl From<#entity_name> for #proj_name {
+            fn from(value: #entity_name) -> Self {
+                Self {
+                    #(#field_mappings),*
+                }
+            }
+        }
+
+        #marker
+        impl From<&#entity_name> for #proj_name {
+            fn from(value: &#entity_name) -> Self {
+                Self {
+                    #(#field_mappings),*
+                }
+            }
+        }
+    }
+}

--- a/tests/cases/pass/projection.rs
+++ b/tests/cases/pass/projection.rs
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Test for `#[projection]` attribute.
+
+use chrono::{DateTime, Utc};
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "users")]
+#[projection(Public: id, name)]
+#[projection(Admin: id, name, email, created_at)]
+pub struct User {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub name: String,
+
+    #[field(create, response)]
+    pub email: String,
+
+    #[field(skip)]
+    pub password_hash: String,
+
+    #[field(response)]
+    #[auto]
+    pub created_at: DateTime<Utc>,
+}
+
+fn main() {
+    // Verify projection structs exist
+    let _: fn(UserPublic) = |_| {};
+    let _: fn(UserAdmin) = |_| {};
+
+    // Verify From impls exist
+    fn _check_from_public(_: impl From<User>) {}
+    fn _check_from_admin(_: impl From<User>) {}
+
+    _check_from_public(UserPublic { id: Uuid::nil(), name: String::new() });
+    _check_from_admin(UserAdmin {
+        id: Uuid::nil(),
+        name: String::new(),
+        email: String::new(),
+        created_at: Utc::now(),
+    });
+}


### PR DESCRIPTION
## Summary
- Add `#[projection(Name: field1, field2)]` attribute for defining partial entity views
- Generate `{Entity}{Projection}` structs with only specified fields
- Generate `find_by_id_{projection}` repository methods with optimized SELECT queries
- Add `From<Entity>` and `From<&Entity>` implementations for projections

## Test plan
- [x] Compile tests pass (`cargo test --all-features compile_pass`)
- [x] Clippy passes with no warnings
- [x] Documentation updated in lib.rs

## Usage example
```rust
#[derive(Entity)]
#[entity(table = "users")]
#[projection(Public: id, name)]
#[projection(Admin: id, name, email, role)]
pub struct User { ... }

// Generated:
// - UserPublic { id, name }
// - UserAdmin { id, name, email, role }
// - find_by_id_public() -> SELECT id, name FROM ...
// - find_by_id_admin() -> SELECT id, name, email, role FROM ...
```

Closes #8