### PR TITLE
#9 feat: entity lifecycle events

### DIFF
--- a/crates/entity-core/src/prelude.rs
+++ b/crates/entity-core/src/prelude.rs
@@ -9,4 +9,4 @@
 //! use entity_core::prelude::*;
 //! ```
 
-pub use crate::{Pagination, Repository, SortDirection, async_trait};
+pub use crate::{EntityEvent, EventKind, Pagination, Repository, SortDirection, async_trait};

--- a/crates/entity-derive-impl/src/entity.rs
+++ b/crates/entity-derive-impl/src/entity.rs
@@ -15,6 +15,7 @@
 //! ├── parse/         → Attribute parsing (EntityDef, FieldDef)
 //! │
 //! ├── dto.rs         → CreateRequest, UpdateRequest, Response
+//! ├── events.rs      → Lifecycle event enum (Created, Updated, etc.)
 //! ├── repository.rs  → Repository trait definition
 //! ├── row.rs         → Database row struct (sqlx::FromRow)
 //! ├── insertable.rs  → Insertable struct for INSERT operations
@@ -55,6 +56,7 @@
 //! | `impl UserRepository for PgPool` | PostgreSQL implementation |
 
 mod dto;
+mod events;
 mod insertable;
 mod mappers;
 pub mod parse;
@@ -84,6 +86,7 @@ fn generate(entity: EntityDef) -> TokenStream {
     let dto = dto::generate(&entity);
     let projections = projection::generate(&entity);
     let query_struct = query::generate(&entity);
+    let events = events::generate(&entity);
     let repository = repository::generate(&entity);
     let row = row::generate(&entity);
     let insertable = insertable::generate(&entity);
@@ -94,6 +97,7 @@ fn generate(entity: EntityDef) -> TokenStream {
         #dto
         #projections
         #query_struct
+        #events
         #repository
         #row
         #insertable

--- a/crates/entity-derive-impl/src/entity/events.rs
+++ b/crates/entity-derive-impl/src/entity/events.rs
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Lifecycle event enum generation.
+//!
+//! Generates an event enum for entities with `#[entity(events)]`.
+//!
+//! # Generated Code
+//!
+//! For an entity `User`, generates:
+//!
+//! ```rust,ignore
+//! #[derive(Debug, Clone)]
+//! pub enum UserEvent {
+//!     Created(User),
+//!     Updated { old: User, new: User },
+//!     SoftDeleted { id: Uuid },
+//!     HardDeleted { id: Uuid },
+//!     Restored { id: Uuid },
+//! }
+//!
+//! impl entity_core::EntityEvent for UserEvent {
+//!     type Id = Uuid;
+//!
+//!     fn kind(&self) -> entity_core::EventKind { ... }
+//!     fn entity_id(&self) -> &Self::Id { ... }
+//! }
+//! ```
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use super::parse::EntityDef;
+use crate::utils::marker;
+
+/// Generates the lifecycle event enum for an entity.
+///
+/// Returns empty `TokenStream` if `events` is not enabled.
+pub fn generate(entity: &EntityDef) -> TokenStream {
+    if !entity.has_events() {
+        return TokenStream::new();
+    }
+
+    let vis = &entity.vis;
+    let entity_name = entity.name();
+    let event_name = format_ident!("{}Event", entity_name);
+
+    let id_type = entity
+        .id_field()
+        .map(|f| f.ty())
+        .unwrap_or_else(|| panic!("Entity must have an #[id] field for events"));
+
+    let soft_delete_variants = if entity.is_soft_delete() {
+        quote! {
+            /// Entity was soft-deleted (marked as deleted but not removed).
+            SoftDeleted {
+                /// ID of the soft-deleted entity.
+                id: #id_type,
+            },
+
+            /// Entity was restored from soft-delete.
+            Restored {
+                /// ID of the restored entity.
+                id: #id_type,
+            },
+        }
+    } else {
+        TokenStream::new()
+    };
+
+    let soft_delete_kind_arms = if entity.is_soft_delete() {
+        quote! {
+            Self::SoftDeleted { .. } => entity_core::EventKind::SoftDeleted,
+            Self::Restored { .. } => entity_core::EventKind::Restored,
+        }
+    } else {
+        TokenStream::new()
+    };
+
+    let soft_delete_id_arms = if entity.is_soft_delete() {
+        quote! {
+            Self::SoftDeleted { id } => id,
+            Self::Restored { id } => id,
+        }
+    } else {
+        TokenStream::new()
+    };
+
+    let marker = marker::generated();
+
+    quote! {
+        #marker
+        /// Lifecycle events for [`#entity_name`].
+        ///
+        /// Emitted during CRUD operations when `events` is enabled.
+        /// Use these events for audit logging, cache invalidation,
+        /// notifications, or the outbox pattern.
+        #[derive(Debug, Clone)]
+        #vis enum #event_name {
+            /// Entity was created.
+            Created(#entity_name),
+
+            /// Entity was updated.
+            Updated {
+                /// Entity state before the update.
+                old: #entity_name,
+                /// Entity state after the update.
+                new: #entity_name,
+            },
+
+            /// Entity was permanently deleted.
+            HardDeleted {
+                /// ID of the deleted entity.
+                id: #id_type,
+            },
+
+            #soft_delete_variants
+        }
+
+        impl #event_name {
+            /// Create a new Created event.
+            pub fn created(entity: #entity_name) -> Self {
+                Self::Created(entity)
+            }
+
+            /// Create a new Updated event.
+            pub fn updated(old: #entity_name, new: #entity_name) -> Self {
+                Self::Updated { old, new }
+            }
+
+            /// Create a new HardDeleted event.
+            pub fn hard_deleted(id: #id_type) -> Self {
+                Self::HardDeleted { id }
+            }
+        }
+
+        impl entity_core::EntityEvent for #event_name {
+            type Id = #id_type;
+
+            fn kind(&self) -> entity_core::EventKind {
+                match self {
+                    Self::Created(_) => entity_core::EventKind::Created,
+                    Self::Updated { .. } => entity_core::EventKind::Updated,
+                    Self::HardDeleted { .. } => entity_core::EventKind::HardDeleted,
+                    #soft_delete_kind_arms
+                }
+            }
+
+            fn entity_id(&self) -> &Self::Id {
+                match self {
+                    Self::Created(e) => &e.id,
+                    Self::Updated { new, .. } => &new.id,
+                    Self::HardDeleted { id } => id,
+                    #soft_delete_id_arms
+                }
+            }
+        }
+    }
+}

--- a/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
@@ -19,6 +19,7 @@
 //! | `error` | No | `sqlx::Error` | Custom error type |
 //! | `soft_delete` | No | `false` | Enable soft delete |
 //! | `returning` | No | `Full` | RETURNING clause mode |
+//! | `events` | No | `false` | Generate lifecycle events |
 
 use darling::FromDeriveInput;
 use syn::{Ident, Visibility};
@@ -144,5 +145,26 @@ pub struct EntityAttrs {
     /// #[entity(table = "logs", returning = "none")]
     /// ```
     #[darling(default)]
-    pub returning: ReturningMode
+    pub returning: ReturningMode,
+
+    /// Generate lifecycle event enum.
+    ///
+    /// When enabled, generates a `{Entity}Event` enum with variants for
+    /// each lifecycle operation (Created, Updated, Deleted, etc.).
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// #[entity(table = "users", events)]
+    /// pub struct User { ... }
+    ///
+    /// // Generates:
+    /// pub enum UserEvent {
+    ///     Created(User),
+    ///     Updated { old: User, new: User },
+    ///     Deleted { id: Uuid },
+    /// }
+    /// ```
+    #[darling(default)]
+    pub events: bool
 }

--- a/crates/entity-derive-impl/src/entity/parse/entity/mod.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/mod.rs
@@ -162,7 +162,13 @@ pub struct EntityDef {
     /// RETURNING clause mode for INSERT/UPDATE operations.
     ///
     /// Controls what data is fetched back from the database after writes.
-    pub returning: ReturningMode
+    pub returning: ReturningMode,
+
+    /// Whether to generate lifecycle events.
+    ///
+    /// When `true`, generates a `{Entity}Event` enum with variants for
+    /// Created, Updated, Deleted, etc.
+    pub events: bool
 }
 
 impl EntityDef {
@@ -239,7 +245,8 @@ impl EntityDef {
             has_many,
             projections,
             soft_delete: attrs.soft_delete,
-            returning: attrs.returning
+            returning: attrs.returning,
+            events: attrs.events
         })
     }
 
@@ -489,6 +496,15 @@ impl EntityDef {
     /// `true` if `#[entity(soft_delete)]` is present.
     pub fn is_soft_delete(&self) -> bool {
         self.soft_delete
+    }
+
+    /// Check if lifecycle events should be generated.
+    ///
+    /// # Returns
+    ///
+    /// `true` if `#[entity(events)]` is present.
+    pub fn has_events(&self) -> bool {
+        self.events
     }
 }
 

--- a/crates/entity-derive/tests/cases/pass/events.rs
+++ b/crates/entity-derive/tests/cases/pass/events.rs
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::{Entity, EntityEvent, EventKind};
+use uuid::Uuid;
+
+#[derive(Entity, Debug, Clone)]
+#[entity(table = "products", events)]
+pub struct Product {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub name: String,
+
+    #[field(create, update, response)]
+    pub price: i64,
+}
+
+fn main() {
+    let product = Product {
+        id: Uuid::nil(),
+        name: "Widget".to_string(),
+        price: 100,
+    };
+
+    // Test Created event
+    let event = ProductEvent::created(product.clone());
+    assert_eq!(event.kind(), EventKind::Created);
+    assert_eq!(event.entity_id(), &Uuid::nil());
+
+    // Test Updated event
+    let old = product.clone();
+    let mut new = product.clone();
+    new.price = 150;
+    let event = ProductEvent::updated(old, new);
+    assert_eq!(event.kind(), EventKind::Updated);
+
+    // Test HardDeleted event
+    let event = ProductEvent::hard_deleted(Uuid::nil());
+    assert_eq!(event.kind(), EventKind::HardDeleted);
+    assert_eq!(event.entity_id(), &Uuid::nil());
+}

--- a/crates/entity-derive/tests/cases/pass/events_soft_delete.rs
+++ b/crates/entity-derive/tests/cases/pass/events_soft_delete.rs
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::{Entity, EntityEvent, EventKind};
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+
+#[derive(Entity, Debug, Clone)]
+#[entity(table = "articles", events, soft_delete)]
+pub struct Article {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub title: String,
+
+    #[field(response)]
+    pub deleted_at: Option<DateTime<Utc>>,
+}
+
+fn main() {
+    let id = Uuid::nil();
+
+    // Test SoftDeleted event
+    let event = ArticleEvent::SoftDeleted { id };
+    assert_eq!(event.kind(), EventKind::SoftDeleted);
+    assert!(event.kind().is_delete());
+
+    // Test Restored event
+    let event = ArticleEvent::Restored { id };
+    assert_eq!(event.kind(), EventKind::Restored);
+    assert!(!event.kind().is_mutation());
+
+    // Test HardDeleted event
+    let event = ArticleEvent::hard_deleted(id);
+    assert_eq!(event.kind(), EventKind::HardDeleted);
+    assert!(event.kind().is_delete());
+}


### PR DESCRIPTION
## Summary

- Add `events` attribute to generate lifecycle event enum
- Add `EventKind` and `EntityEvent` trait to entity-core

Closes #9

## Usage

```rust
#[entity(table = "users", events)]
pub struct User { ... }

// Generates UserEvent enum
let event = UserEvent::created(user);
assert_eq!(event.kind(), EventKind::Created);
```

## Generated Code

```rust
pub enum UserEvent {
    Created(User),
    Updated { old: User, new: User },
    HardDeleted { id: Uuid },
    // With soft_delete:
    SoftDeleted { id: Uuid },
    Restored { id: Uuid },
}

impl EntityEvent for UserEvent {
    fn kind(&self) -> EventKind;
    fn entity_id(&self) -> &Uuid;
}
```