### PR TITLE
#42 fix: replace expect() with proper error handling in field parsing

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/entity/mod.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/mod.rs
@@ -224,9 +224,11 @@ impl EntityDef {
 
         let fields: Vec<FieldDef> = match &input.data {
             syn::Data::Struct(data) => match &data.fields {
-                syn::Fields::Named(named) => {
-                    named.named.iter().map(FieldDef::from_field).collect()
-                }
+                syn::Fields::Named(named) => named
+                    .named
+                    .iter()
+                    .map(FieldDef::from_field)
+                    .collect::<darling::Result<Vec<_>>>()?,
                 _ => {
                     return Err(darling::Error::custom("Entity requires named fields")
                         .with_span(&input.ident));

--- a/crates/entity-derive-impl/src/entity/parse/field.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field.rs
@@ -87,8 +87,14 @@ impl FieldDef {
     ///
     /// Extracts base information and parses all attributes into
     /// exposure and storage configurations.
-    pub fn from_field(field: &Field) -> Self {
-        let ident = field.ident.clone().expect("named field required");
+    ///
+    /// # Errors
+    ///
+    /// Returns error if the field has no identifier (tuple struct field).
+    pub fn from_field(field: &Field) -> darling::Result<Self> {
+        let ident = field.ident.clone().ok_or_else(|| {
+            darling::Error::custom("Entity fields must be named").with_span(field)
+        })?;
         let ty = field.ty.clone();
         let vis = field.vis.clone();
 
@@ -110,14 +116,14 @@ impl FieldDef {
             }
         }
 
-        Self {
+        Ok(Self {
             ident,
             ty,
             vis,
             expose,
             storage,
             filter
-        }
+        })
     }
 
     /// Get the field name as an identifier.


### PR DESCRIPTION
## Summary

- Change `FieldDef::from_field()` to return `darling::Result<Self>`
- Replace `expect()` with `ok_or_else()` returning proper error
- Update calling site in `EntityDef::from_derive_input()`

Closes #42