### PR TITLE
#43 fix: use compile-time parse_quote! for default error type

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
@@ -37,8 +37,9 @@ pub fn default_schema() -> String {
 /// Default error type path for SQL implementations.
 ///
 /// Used when no custom error type is specified.
+/// Uses `parse_quote!` for compile-time validation.
 pub fn default_error_type() -> syn::Path {
-    syn::parse_str("sqlx::Error").expect("valid path")
+    syn::parse_quote!(sqlx::Error)
 }
 
 /// Entity-level attributes parsed from `#[entity(...)]`.


### PR DESCRIPTION
## Summary

- Replace `syn::parse_str().expect()` with `syn::parse_quote!()`
- Compile-time validation eliminates runtime panic possibility

Closes #43