### PR TITLE
#44 fix: replace unreachable!() with graceful handling

### DIFF
--- a/crates/entity-derive-impl/src/entity/query.rs
+++ b/crates/entity-derive-impl/src/entity/query.rs
@@ -78,8 +78,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
                         quote! { pub #to_name: Option<#ty> },
                     ]
                 }
-                // Unreachable: filter_fields() only returns fields with has_filter() == true
-                FilterType::None => unreachable!("FilterType::None should not be in filter_fields")
+                // Skip: filter_fields() should only return fields with filters
+                FilterType::None => vec![]
             }
         })
         .collect();

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -128,10 +128,9 @@ pub fn generate_where_conditions(fields: &[&FieldDef], soft_delete: bool) -> Tok
                         },
                     ]
                 }
-                // Unreachable: filter_fields() only returns fields with has_filter() == true
-                FilterType::None => {
-                    unreachable!("FilterType::None should not be in filter_fields")
-                }
+                // Skip: filter_fields() should only return fields with filters,
+                // but handle gracefully if None slips through
+                FilterType::None => vec![]
             }
         })
         .collect();
@@ -196,10 +195,9 @@ pub fn generate_query_bindings(fields: &[&FieldDef]) -> TokenStream {
                         },
                     ]
                 }
-                // Unreachable: filter_fields() only returns fields with has_filter() == true
-                FilterType::None => {
-                    unreachable!("FilterType::None should not be in filter_fields")
-                }
+                // Skip: filter_fields() should only return fields with filters,
+                // but handle gracefully if None slips through
+                FilterType::None => vec![]
             }
         })
         .collect();


### PR DESCRIPTION
## Summary

- Replace `unreachable!()` with `vec![]` in filter match arms
- FilterType::None is now silently skipped instead of panicking
- Defensive programming: handle edge cases gracefully

Closes #44