### PR TITLE
#47 fix: escape SQL wildcards in LIKE patterns

### DIFF
--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -176,7 +176,12 @@ pub fn generate_query_bindings(fields: &[&FieldDef]) -> TokenStream {
                 FilterType::Like => {
                     vec![quote! {
                         if let Some(ref v) = query.#name {
-                            q = q.bind(format!("%{}%", v));
+                            // Escape SQL LIKE wildcards to prevent injection
+                            let escaped = v
+                                .replace('\\', "\\\\")
+                                .replace('%', "\\%")
+                                .replace('_', "\\_");
+                            q = q.bind(format!("%{}%", escaped));
                         }
                     }]
                 }


### PR DESCRIPTION
## Summary

- Escape `%`, `_`, and `\` in LIKE filter values
- Prevents unintended wildcard matching (e.g., searching for "100%" no longer matches everything)

Closes #47