### PR TITLE
#48 refactor: remove dead code and unused methods

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/dialect.rs
+++ b/crates/entity-derive-impl/src/entity/parse/dialect.rs
@@ -86,17 +86,6 @@ impl DatabaseDialect {
         }
     }
 
-    /// Get the client type path for this dialect.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn client_type(&self) -> &'static str {
-        match self {
-            Self::Postgres => "sqlx::PgPool",
-            Self::ClickHouse => "clickhouse::Client",
-            Self::MongoDB => "mongodb::Client"
-        }
-    }
-
     /// Get the feature flag name for this dialect.
     #[must_use]
     pub fn feature_flag(&self) -> &'static str {
@@ -105,27 +94,6 @@ impl DatabaseDialect {
             Self::ClickHouse => "clickhouse",
             Self::MongoDB => "mongodb"
         }
-    }
-
-    /// Check if RETURNING clause is supported.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn supports_returning(&self) -> bool {
-        matches!(self, Self::Postgres)
-    }
-
-    /// Check if this is a SQL-based database.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn is_sql(&self) -> bool {
-        matches!(self, Self::Postgres | Self::ClickHouse)
-    }
-
-    /// Check if this is a document database.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn is_document(&self) -> bool {
-        matches!(self, Self::MongoDB)
     }
 }
 
@@ -189,41 +157,10 @@ mod tests {
     }
 
     #[test]
-    fn client_types() {
-        assert_eq!(DatabaseDialect::Postgres.client_type(), "sqlx::PgPool");
-        assert_eq!(
-            DatabaseDialect::ClickHouse.client_type(),
-            "clickhouse::Client"
-        );
-        assert_eq!(DatabaseDialect::MongoDB.client_type(), "mongodb::Client");
-    }
-
-    #[test]
     fn feature_flags() {
         assert_eq!(DatabaseDialect::Postgres.feature_flag(), "postgres");
         assert_eq!(DatabaseDialect::ClickHouse.feature_flag(), "clickhouse");
         assert_eq!(DatabaseDialect::MongoDB.feature_flag(), "mongodb");
-    }
-
-    #[test]
-    fn is_sql() {
-        assert!(DatabaseDialect::Postgres.is_sql());
-        assert!(DatabaseDialect::ClickHouse.is_sql());
-        assert!(!DatabaseDialect::MongoDB.is_sql());
-    }
-
-    #[test]
-    fn is_document() {
-        assert!(!DatabaseDialect::Postgres.is_document());
-        assert!(!DatabaseDialect::ClickHouse.is_document());
-        assert!(DatabaseDialect::MongoDB.is_document());
-    }
-
-    #[test]
-    fn supports_returning() {
-        assert!(DatabaseDialect::Postgres.supports_returning());
-        assert!(!DatabaseDialect::ClickHouse.supports_returning());
-        assert!(!DatabaseDialect::MongoDB.supports_returning());
     }
 
     #[test]

--- a/crates/entity-derive-impl/src/entity/parse/field.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field.rs
@@ -33,7 +33,7 @@ mod storage;
 pub use expose::ExposeConfig;
 pub use filter::{FilterConfig, FilterType};
 pub use storage::StorageConfig;
-use syn::{Attribute, Field, Ident, Type, Visibility};
+use syn::{Attribute, Field, Ident, Type};
 
 /// Parse `#[belongs_to(EntityName)]` attribute.
 ///
@@ -68,10 +68,6 @@ pub struct FieldDef {
     /// Field type (e.g., `Uuid`, `Option<String>`, `DateTime<Utc>`).
     pub ty: Type,
 
-    /// Field visibility.
-    #[allow(dead_code)]
-    pub vis: Visibility,
-
     /// DTO exposure configuration.
     pub expose: ExposeConfig,
 
@@ -90,7 +86,6 @@ impl FieldDef {
     pub fn from_field(field: &Field) -> Self {
         let ident = field.ident.clone().expect("named field required");
         let ty = field.ty.clone();
-        let vis = field.vis.clone();
 
         let mut expose = ExposeConfig::default();
         let mut storage = StorageConfig::default();
@@ -113,7 +108,6 @@ impl FieldDef {
         Self {
             ident,
             ty,
-            vis,
             expose,
             storage,
             filter

--- a/crates/entity-derive-impl/src/entity/parse/field/expose.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/expose.rs
@@ -79,15 +79,6 @@ impl ExposeConfig {
     pub fn in_update(&self) -> bool {
         !self.skip && self.update
     }
-
-    /// Check if field should appear in Response.
-    ///
-    /// Note: ID fields are always included regardless of this flag.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn in_response(&self) -> bool {
-        !self.skip && self.response
-    }
 }
 
 #[cfg(test)]
@@ -113,6 +104,7 @@ mod tests {
         };
         assert!(!config.in_create());
         assert!(!config.in_update());
-        assert!(!config.in_response());
+        // response check is done via FieldDef::in_response() which includes ID logic
+        assert!(config.skip);
     }
 }

--- a/crates/entity-derive-impl/src/entity/parse/field/filter.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/filter.rs
@@ -79,24 +79,6 @@ impl FilterConfig {
     pub fn has_filter(&self) -> bool {
         self.filter_type != FilterType::None
     }
-
-    /// Check if this is an exact match filter.
-    #[allow(dead_code)]
-    pub fn is_eq(&self) -> bool {
-        self.filter_type == FilterType::Eq
-    }
-
-    /// Check if this is a LIKE filter.
-    #[allow(dead_code)]
-    pub fn is_like(&self) -> bool {
-        self.filter_type == FilterType::Like
-    }
-
-    /// Check if this is a range filter.
-    #[allow(dead_code)]
-    pub fn is_range(&self) -> bool {
-        self.filter_type == FilterType::Range
-    }
 }
 
 #[cfg(test)]
@@ -111,37 +93,25 @@ mod tests {
     }
 
     #[test]
-    fn filter_type_checks() {
+    fn has_filter_checks() {
         let eq = FilterConfig {
             filter_type: FilterType::Eq
         };
-        assert!(eq.is_eq());
-        assert!(!eq.is_like());
-        assert!(!eq.is_range());
         assert!(eq.has_filter());
 
         let like = FilterConfig {
             filter_type: FilterType::Like
         };
-        assert!(!like.is_eq());
-        assert!(like.is_like());
-        assert!(!like.is_range());
         assert!(like.has_filter());
 
         let range = FilterConfig {
             filter_type: FilterType::Range
         };
-        assert!(!range.is_eq());
-        assert!(!range.is_like());
-        assert!(range.is_range());
         assert!(range.has_filter());
 
         let none = FilterConfig {
             filter_type: FilterType::None
         };
-        assert!(!none.is_eq());
-        assert!(!none.is_like());
-        assert!(!none.is_range());
         assert!(!none.has_filter());
     }
 }

--- a/crates/entity-derive-impl/src/entity/parse/field/storage.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/storage.rs
@@ -68,35 +68,6 @@ pub struct StorageConfig {
 }
 
 impl StorageConfig {
-    /// Create config for ID field.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn id() -> Self {
-        Self {
-            is_id:      true,
-            is_auto:    false,
-            belongs_to: None
-        }
-    }
-
-    /// Create config for auto-generated field.
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn auto() -> Self {
-        Self {
-            is_id:      false,
-            is_auto:    true,
-            belongs_to: None
-        }
-    }
-
-    /// Check if field value is auto-generated (ID or auto).
-    #[must_use]
-    #[allow(dead_code)]
-    pub fn is_generated(&self) -> bool {
-        self.is_id || self.is_auto
-    }
-
     /// Check if this field is a foreign key relation.
     #[must_use]
     pub fn is_relation(&self) -> bool {
@@ -115,23 +86,6 @@ mod tests {
         let config = StorageConfig::default();
         assert!(!config.is_id);
         assert!(!config.is_auto);
-        assert!(!config.is_generated());
-        assert!(!config.is_relation());
-    }
-
-    #[test]
-    fn id_is_generated() {
-        let config = StorageConfig::id();
-        assert!(config.is_id);
-        assert!(config.is_generated());
-        assert!(!config.is_relation());
-    }
-
-    #[test]
-    fn auto_is_generated() {
-        let config = StorageConfig::auto();
-        assert!(config.is_auto);
-        assert!(config.is_generated());
         assert!(!config.is_relation());
     }
 
@@ -143,6 +97,5 @@ mod tests {
             belongs_to: Some(Ident::new("User", Span::call_site()))
         };
         assert!(config.is_relation());
-        assert!(!config.is_generated());
     }
 }

--- a/crates/entity-derive-impl/src/utils.rs
+++ b/crates/entity-derive-impl/src/utils.rs
@@ -9,8 +9,6 @@
 //!
 //! - [`fields`] — Field assignment generation for `From` implementations
 //! - [`marker`] — Generated code marker comments
-//! - [`sql`] — SQL query building utilities (minimal, most SQL in dialect.rs)
 
 pub mod fields;
 pub mod marker;
-pub mod sql;

--- a/crates/entity-derive-impl/src/utils/sql.rs
+++ b/crates/entity-derive-impl/src/utils/sql.rs
@@ -1,8 +1,0 @@
-// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
-// SPDX-License-Identifier: MIT
-
-//! SQL query building utilities.
-//!
-//! Note: Most SQL generation is now handled by `DatabaseDialect` in
-//! `entity/parse/dialect.rs` and local helpers in `entity/sql.rs`.
-//! This module is kept for potential future shared utilities.


### PR DESCRIPTION
## Summary
- Remove empty `utils/sql.rs` module
- Remove unused `DatabaseDialect` methods: `client_type()`, `supports_returning()`, `is_sql()`, `is_document()`
- Remove unused `StorageConfig` constructors: `id()`, `auto()`, `is_generated()`
- Remove unused `FilterConfig` methods: `is_eq()`, `is_like()`, `is_range()`
- Remove unused `EntityDef` methods: `snake_name()`, `has_custom_error()`
- Remove unused `convert_case` import
- Update tests to reflect removed methods

Coverage: 98.82% lines

Closes #48