### PR TITLE
chore(release): 0.7.1 — ship unit tests from #105

### DIFF
--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.7.0"
+version = "0.7.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes #106

## Summary

0.7.0 was published to crates.io while PR #105 (which added unit tests for `finalize_with_commit`) was still in review. The tests are now in main but the published 0.7.0 tarball lacks them. This PR bumps patch versions so the test additions ship.

| Crate | Old | New |
|---|---|---|
| entity-core | 0.5.0 | 0.5.1 |
| entity-derive-impl | 0.5.0 | 0.5.1 |
| entity-derive | 0.7.0 | 0.7.1 |

Workspace dependency pins use the `0.5` range, already compatible with 0.5.1 — no further edits.

## Test plan

- [x] `cargo check --all-features` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [ ] Full CI green (incl. Codecov) before merge