### PR TITLE
fix(map): emit compile_error for invalid expr and nested-meta failures

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/field/map.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/map.rs
@@ -50,7 +50,7 @@ use syn::{Attribute, Ident};
 ///
 /// Defines how a field should be transformed when mapping from a database row
 /// to the entity struct in the `From<Row> for Entity` implementation.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Default)]
 pub enum MapConfig {
     /// No mapping transformation.
     #[default]
@@ -95,8 +95,9 @@ pub enum MapConfig {
 
     /// Raw expression escape hatch.
     ///
-    /// The expression is used verbatim in the generated code.
-    /// No validation or transformation is applied.
+    /// The expression is parsed lazily in [`MapConfig::generate`]. If the
+    /// string is not a valid Rust expression, generation emits a
+    /// `compile_error!` instead of producing empty tokens.
     ///
     /// # Example
     ///
@@ -104,7 +105,14 @@ pub enum MapConfig {
     /// #[map(expr = "row.raw_value.parse().unwrap_or(0)")]
     /// pub field: i32
     /// ```
-    Expr(String)
+    Expr(String),
+
+    /// Attribute parsing failed.
+    ///
+    /// Stores the [`syn::Error`] surfaced while interpreting `#[map(...)]`.
+    /// [`MapConfig::generate`] turns this into a `compile_error!` so the
+    /// user sees a diagnostic instead of silently degraded codegen.
+    Invalid(syn::Error)
 }
 
 impl MapConfig {
@@ -135,7 +143,7 @@ impl MapConfig {
 
                 // Try nested meta: #[map(empty_to_none, expr = "...")]
                 let mut result = Self::None;
-                let _ = meta_list.parse_nested_meta(|meta| {
+                if let Err(err) = meta_list.parse_nested_meta(|meta| {
                     if meta.path.is_ident("empty_to_none") {
                         result = Self::EmptyToNone;
                     } else if meta.path.is_ident("unwrap_default") {
@@ -148,7 +156,9 @@ impl MapConfig {
                         result = Self::Expr(value.value());
                     }
                     Ok(())
-                });
+                }) {
+                    return Some(Self::Invalid(err));
+                }
 
                 Some(result)
             }
@@ -217,10 +227,16 @@ impl MapConfig {
             Self::Now => {
                 quote! { Some(#source_name.#field_name.unwrap_or_else(chrono::Utc::now)) }
             }
-            Self::Expr(expr) => {
-                let expr_tokens: TokenStream = expr.parse().unwrap_or_default();
-                quote! { #expr_tokens }
-            }
+            Self::Expr(expr) => match syn::parse_str::<syn::Expr>(expr) {
+                Ok(parsed) => quote! { #parsed },
+                Err(e) => {
+                    let msg = format!(
+                        "`#[map(expr = \"...\")]` contains an invalid Rust expression: {e}"
+                    );
+                    quote! { compile_error!(#msg) }
+                }
+            },
+            Self::Invalid(err) => err.to_compile_error()
         }
     }
 }
@@ -427,5 +443,73 @@ mod tests {
         let tokens = config.generate(&field, &source);
         let tokens_str = tokens.to_string();
         assert!(tokens_str.contains("unwrap_or"));
+    }
+
+    // Regression tests for error reporting in `#[map(...)]` parsing.
+    //
+    // Previously, `MapConfig::generate` swallowed parse errors via
+    // `unwrap_or_default()` and `MapConfig::from_attr` discarded
+    // `parse_nested_meta` errors via `let _ = ...`. Both paths now surface
+    // diagnostics as `compile_error!` tokens.
+
+    #[test]
+    fn generate_expr_invalid_syntax_emits_compile_error() {
+        let config = MapConfig::Expr("invalid $$$ rust".to_string());
+        let field = Ident::new("any", proc_macro2::Span::call_site());
+        let source = Ident::new("row", proc_macro2::Span::call_site());
+        let tokens = config.generate(&field, &source).to_string();
+        assert!(
+            tokens.contains("compile_error"),
+            "expected compile_error! token, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("invalid Rust expression"),
+            "expected diagnostic message, got: {tokens}"
+        );
+    }
+
+    #[test]
+    fn generate_expr_invalid_syntax_is_not_empty_tokenstream() {
+        // Regression: the old code returned `TokenStream::default()` on parse
+        // failure, which produced cryptic downstream errors. The new code
+        // must emit a non-empty diagnostic.
+        let config = MapConfig::Expr("$$$".to_string());
+        let field = Ident::new("any", proc_macro2::Span::call_site());
+        let source = Ident::new("row", proc_macro2::Span::call_site());
+        let tokens = config.generate(&field, &source);
+        assert!(
+            !tokens.is_empty(),
+            "compile_error! must be emitted instead of empty tokens"
+        );
+    }
+
+    #[test]
+    fn from_attr_invalid_nested_meta_becomes_invalid_variant() {
+        // `expr` requires `= "..."`; using `expr(foo)` is malformed and the
+        // nested-meta parser should report it. Previously the error was
+        // dropped, leaving `MapConfig::None` and no diagnostic.
+        let attr: Attribute = parse_quote!(#[map(empty_to_none, expr(foo))]);
+        let config = MapConfig::from_attr(&attr);
+        assert!(
+            matches!(config, Some(MapConfig::Invalid(_))),
+            "expected Invalid variant carrying the parse error, got: {config:?}"
+        );
+    }
+
+    #[test]
+    fn invalid_variant_generates_compile_error_tokens() {
+        let err = syn::Error::new(proc_macro2::Span::call_site(), "bad map attr");
+        let config = MapConfig::Invalid(err);
+        let field = Ident::new("any", proc_macro2::Span::call_site());
+        let source = Ident::new("row", proc_macro2::Span::call_site());
+        let tokens = config.generate(&field, &source).to_string();
+        assert!(
+            tokens.contains("compile_error"),
+            "Invalid must emit compile_error!, got: {tokens}"
+        );
+        assert!(
+            tokens.contains("bad map attr"),
+            "error message must be preserved, got: {tokens}"
+        );
     }
 }

--- a/crates/entity-derive-impl/src/utils/fields.rs
+++ b/crates/entity-derive-impl/src/utils/fields.rs
@@ -157,7 +157,7 @@ pub fn row_assigns(fields: &[FieldDef], source: &str) -> Vec<TokenStream> {
         .map(|f: &FieldDef| {
             let name = f.name();
             let map = f.map();
-            if map == &MapConfig::None {
+            if matches!(map, MapConfig::None) {
                 quote! { #name: #src.#name }
             } else {
                 let expr = map.generate(name, &src);

--- a/crates/entity-derive/tests/cases/fail/map_expr_invalid.rs
+++ b/crates/entity-derive/tests/cases/fail/map_expr_invalid.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+/// `#[map(expr = "...")]` with non-parseable Rust must report a clear
+/// compile error at the use site instead of silently producing empty
+/// tokens (which previously caused cryptic unrelated errors).
+#[derive(Entity)]
+#[entity(table = "items")]
+pub struct Item {
+    #[id]
+    pub id: Uuid,
+
+    #[field(response)]
+    #[map(expr = "invalid $$$ rust")]
+    pub broken: i32,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/map_expr_invalid.stderr
+++ b/crates/entity-derive/tests/cases/fail/map_expr_invalid.stderr
@@ -1,0 +1,7 @@
+error: `#[map(expr = "...")]` contains an invalid Rust expression: unexpected token
+  --> tests/cases/fail/map_expr_invalid.rs:10:10
+   |
+10 | #[derive(Entity)]
+   |          ^^^^^^
+   |
+   = note: this error originates in the derive macro `Entity` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/entity-derive/tests/cases/fail/map_nested_meta_invalid.rs
+++ b/crates/entity-derive/tests/cases/fail/map_nested_meta_invalid.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+/// Malformed nested meta inside `#[map(...)]` must surface a compile error
+/// from the attribute parser rather than silently degrading to
+/// `MapConfig::None`.
+#[derive(Entity)]
+#[entity(table = "items")]
+pub struct Item {
+    #[id]
+    pub id: Uuid,
+
+    #[field(response)]
+    #[map(empty_to_none, expr(missing_equals))]
+    pub broken: Option<String>,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/map_nested_meta_invalid.stderr
+++ b/crates/entity-derive/tests/cases/fail/map_nested_meta_invalid.stderr
@@ -1,0 +1,5 @@
+error: expected `=`
+  --> tests/cases/fail/map_nested_meta_invalid.rs:17:30
+   |
+17 |     #[map(empty_to_none, expr(missing_equals))]
+   |                              ^


### PR DESCRIPTION
Closes #108

## Summary

`#[map(...)]` parsing previously swallowed errors:

- `MapConfig::generate` for `Expr` did `expr.parse().unwrap_or_default()` — empty TokenStream on parse failure, cryptic downstream errors.
- `MapConfig::from_attr` bound `parse_nested_meta` errors to `_`, silently degrading to `MapConfig::None`.

Both paths now emit a clear \`compile_error!\` at the attribute site.

## Changes

- New `MapConfig::Invalid(syn::Error)` variant carrying the parse diagnostic.
- `generate` for `Expr` parses lazily; on failure emits `compile_error!` mentioning the invalid Rust expression.
- `from_attr` propagates `parse_nested_meta` errors as `Invalid(err)`.
- `Invalid::generate` returns `err.to_compile_error()`, preserving span + message.
- `PartialEq`/`Eq` derives removed from `MapConfig` (`syn::Error` does not implement them); single \`==\` callsite switched to \`matches!\`.

## Tests

- 4 lib unit tests cover diagnostics:
  - `generate_expr_invalid_syntax_emits_compile_error`
  - `generate_expr_invalid_syntax_is_not_empty_tokenstream`
  - `from_attr_invalid_nested_meta_becomes_invalid_variant`
  - `invalid_variant_generates_compile_error_tokens`
- 2 trybuild fail cases + `.stderr` fixtures lock user-facing wording:
  - `tests/cases/fail/map_expr_invalid.rs`
  - `tests/cases/fail/map_nested_meta_invalid.rs`

## Test plan

- [x] `cargo test --all-features` — full suite passes (538 lib tests incl. 4 new + trybuild)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [ ] Full CI green incl. Codecov before merge