### PR TITLE
fix(transactions): deprecate with_*() no-op builder + release 0.7.2

### DIFF
--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-core/src/transaction.rs
+++ b/crates/entity-core/src/transaction.rs
@@ -20,8 +20,6 @@
 //!
 //! async fn transfer(pool: &PgPool, from: Uuid, to: Uuid, amount: i64) -> Result<(), AppError> {
 //!     Transaction::new(pool)
-//!         .with_accounts()
-//!         .with_transfers()
 //!         .run(async |ctx| {
 //!             let from_acc = ctx.accounts().find_by_id(from).await?.ok_or(AppError::NotFound)?;
 //!
@@ -55,8 +53,6 @@ use std::{error::Error as StdError, fmt};
 ///
 /// ```rust,ignore
 /// Transaction::new(&pool)
-///     .with_users()
-///     .with_orders()
 ///     .run(async |ctx| {
 ///         let user = ctx.users().find_by_id(id).await?;
 ///         ctx.orders().create(order).await?;
@@ -294,7 +290,6 @@ impl Transaction<'_, sqlx::PgPool> {
     ///
     /// ```rust,ignore
     /// Transaction::new(&pool)
-    ///     .with_users()
     ///     .run(async |ctx| {
     ///         let user = ctx.users().create(dto).await?;
     ///         Ok(user)

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
@@ -233,7 +233,6 @@ pub struct EntityAttrs {
     ///
     /// // Usage:
     /// Transaction::new(&pool)
-    ///     .with_accounts()
     ///     .run(async |ctx| {
     ///         ctx.accounts().create(dto).await
     ///     })

--- a/crates/entity-derive-impl/src/entity/transaction.rs
+++ b/crates/entity-derive-impl/src/entity/transaction.rs
@@ -11,15 +11,13 @@
 //! For an entity `User` with `#[entity(transactions)]`:
 //!
 //! - `UserTransactionRepo<'t>` — Repository adapter for transaction context
-//! - `with_users()` — Builder method on `Transaction` (fluent, chainable)
+//! - `with_users()` — Deprecated no-op builder, kept for source compatibility
 //! - `users()` — Accessor method on `TransactionContext`
 //!
 //! # Example
 //!
 //! ```rust,ignore
 //! Transaction::new(&pool)
-//!     .with_users()
-//!     .with_orders()
 //!     .run(async |ctx| {
 //!         let user = ctx.users().find_by_id(id).await?;
 //!         ctx.orders().create(order).await?;
@@ -211,7 +209,16 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
 /// Generate the builder extension trait.
 ///
 /// Creates an extension trait that adds `with_{entities}()` method to
-/// `Transaction`. This method is chainable and returns self.
+/// `Transaction`. The method is a deprecated no-op kept only for source
+/// compatibility with code written against earlier 0.x releases.
+///
+/// Repository access happens inside the closure passed to `run` /
+/// `run_with_commit` via the `ContextExt` trait
+/// (e.g. `ctx.users().find_by_id(id).await?`), independently of whether
+/// `with_*` was called. The fluent chain therefore does not actually
+/// register anything; users should drop the calls.
+///
+/// Planned removal: 0.8.0.
 fn generate_builder_extension(entity: &EntityDef) -> TokenStream {
     let vis = &entity.vis;
     let entity_name = entity.name();
@@ -221,17 +228,25 @@ fn generate_builder_extension(entity: &EntityDef) -> TokenStream {
     let method_name = format_ident!("with_{}", plural);
     let trait_name = format_ident!("TransactionWith{}", entity_name);
     let marker = marker::generated();
+    let deprecation_note = format!(
+        "no-op; repositories are accessed via `ctx.{plural}()` inside the closure of \
+         `Transaction::run` / `run_with_commit`. Drop the `.{method_name}()` call. \
+         Slated for removal in 0.8.0."
+    );
 
     quote! {
         #marker
-        /// Extension trait to add #entity_name to a transaction builder.
+        /// Extension trait left for source compatibility with earlier 0.x releases.
         ///
-        /// This is a fluent API method - it returns self for chaining.
-        /// The actual repository is accessed via `ctx.{entities}()` in the closure.
+        /// **Deprecated** — the method is a no-op. Repositories are accessed via
+        /// `ctx.<entities>()` inside the closure of `Transaction::run` /
+        /// `run_with_commit`, independent of whether this method is called.
+        /// Planned for removal in 0.8.0.
         #vis trait #trait_name<'p> {
-            /// Add #entity_name repository to the transaction.
+            /// Deprecated no-op kept for source compatibility.
             ///
-            /// Returns self for chaining with other `with_*` calls.
+            /// See the trait docs for the supported usage.
+            #[deprecated(note = #deprecation_note)]
             fn #method_name(self) -> Self;
         }
 

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.7.1"
+version = "0.7.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/examples/full-app/src/main.rs
+++ b/examples/full-app/src/main.rs
@@ -254,9 +254,6 @@ async fn place_order(
     }
 
     let result = Transaction::new(&*pool)
-        .with_orders()
-        .with_order_items()
-        .with_products()
         .run(async |ctx| {
             // Create order
             let order = ctx

--- a/examples/transactions/src/main.rs
+++ b/examples/transactions/src/main.rs
@@ -102,8 +102,6 @@ async fn transfer(
     }
 
     let result = Transaction::new(&*state.pool)
-        .with_bank_accounts()
-        .with_transfer_logs()
         .run(async |ctx| {
             // Step 1: Get source account
             let from = ctx


### PR DESCRIPTION
Closes #110

## Summary

The generated `with_<entities>()` methods on `Transaction` are no-ops — their body is just `self`. Repositories are accessed inside the closure via `ContextExt` (`ctx.<entities>()`), independently of whether \`with_*\` was called. The fluent chain misleads users into thinking they register repositories.

This PR is **phase 1 of a two-step deprecation**:

1. **0.7.2 (this PR):** mark the generated method `#[deprecated]` with a clear note, update docs and examples.
2. **0.8.0 (follow-up):** remove the generated trait/impl entirely.

## Changes

- `crates/entity-derive-impl/src/entity/transaction.rs::generate_builder_extension`:
  - Generated method now carries `#[deprecated(note = "no-op; repositories are accessed via `ctx.<entity>()` inside the closure of `Transaction::run` / `run_with_commit`. Drop the `.<method>()` call. Slated for removal in 0.8.0.")]`.
  - Trait + method doc comments updated to explain the no-op status.
- Doc strings in `entity-derive-impl/src/entity/transaction.rs` (module level), `entity-derive-impl/src/entity/parse/entity/attrs.rs` (`transactions` field), and `entity-core/src/transaction.rs` (module + struct + `run`) drop the `with_*` calls from examples.
- `examples/transactions/src/main.rs` and `examples/full-app/src/main.rs` drop `.with_*` so our own builds stay warning-free.

## Release bundling

This PR also bumps versions to ship the #108 map diagnostics fix (merged in #109, no version bump there):

| Crate | Old | New |
|---|---|---|
| entity-core | 0.5.1 | 0.5.2 |
| entity-derive-impl | 0.5.1 | 0.5.2 |
| entity-derive | 0.7.1 | 0.7.2 |

## Test plan

- [x] `cargo test --all-features` — 538 lib tests + doctests + trybuild all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo check` on `examples/transactions` and `examples/full-app` — clean, no deprecation warnings (no `with_*` calls remaining)
- [ ] Full CI green incl. Codecov before merge