### PR TITLE
docs(transactions): make run_with_commit's silent-rollback contract impossible to miss

### DIFF
--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-core/src/transaction.rs
+++ b/crates/entity-core/src/transaction.rs
@@ -313,21 +313,63 @@ impl Transaction<'_, sqlx::PgPool> {
 
     /// Execute a closure within a transaction with explicit commit.
     ///
-    /// Unlike [`run`](Self::run), this method passes `TransactionContext` by
-    /// value so the closure can call `ctx.commit().await` (or
-    /// `ctx.rollback().await`) itself. If the closure returns without
-    /// committing, the transaction is rolled back when `ctx` is dropped.
+    /// # ⚠️ The closure MUST call `ctx.commit().await` on every successful path
     ///
-    /// Use this when you need conditional commit logic; otherwise prefer `run`.
+    /// `run_with_commit` hands ownership of [`TransactionContext`] to the
+    /// closure. There is no type-level guarantee that the closure commits;
+    /// if it returns `Ok(...)` without calling
+    /// [`commit`][TransactionContext::commit], `ctx` is dropped and the
+    /// underlying `sqlx::Transaction::Drop` **silently rolls back**. The
+    /// caller observes `Ok` and assumes the writes persisted — they did
+    /// not. This is the same failure mode that affected the old `run()`
+    /// implementation; here it is preserved on purpose so callers can
+    /// implement conditional commit logic, at the cost of moving the
+    /// responsibility onto the closure.
     ///
-    /// # Example
+    /// **Prefer [`run`](Self::run) unless you genuinely need to decide
+    /// commit-or-rollback inside the closure.** `run` performs the commit
+    /// automatically on `Ok` and rolls back on `Err`, eliminating this
+    /// footgun.
+    ///
+    /// # Examples
+    ///
+    /// **Correct** — closure commits on the success path:
     ///
     /// ```rust,ignore
     /// Transaction::new(&pool)
     ///     .run_with_commit(|mut ctx| async move {
     ///         let user = ctx.users().create(dto).await?;
-    ///         ctx.commit().await?;
+    ///         ctx.commit().await?;     // <-- required
     ///         Ok(user)
+    ///     })
+    ///     .await?;
+    /// ```
+    ///
+    /// **Wrong** — closure returns `Ok` without committing; the write is
+    /// rolled back when `ctx` drops, but the caller sees `Ok(user)`:
+    ///
+    /// ```rust,ignore
+    /// Transaction::new(&pool)
+    ///     .run_with_commit(|mut ctx| async move {
+    ///         let user = ctx.users().create(dto).await?;
+    ///         // BUG: forgot `ctx.commit().await?` — the row is rolled back.
+    ///         Ok(user)
+    ///     })
+    ///     .await?;
+    /// ```
+    ///
+    /// **Conditional commit** — the intended use case:
+    ///
+    /// ```rust,ignore
+    /// Transaction::new(&pool)
+    ///     .run_with_commit(|mut ctx| async move {
+    ///         let user = ctx.users().create(dto).await?;
+    ///         if user.flagged {
+    ///             ctx.rollback().await?;
+    ///             return Ok(None);
+    ///         }
+    ///         ctx.commit().await?;
+    ///         Ok(Some(user))
     ///     })
     ///     .await?;
     /// ```


### PR DESCRIPTION
Closes #112

## Summary

\`Transaction::run_with_commit\` hands \`TransactionContext\` to the closure by value. If the closure returns \`Ok\` without calling \`ctx.commit().await\`, \`sqlx::Transaction::Drop\` rolls back silently — same failure mode as the old broken \`run()\`, kept here intentionally for conditional-commit flows.

The previous doc comment buried this in a single sentence. Now it's a prominent warning block plus three example pairs (right / wrong / conditional).

## Changes

- \`crates/entity-core/src/transaction.rs::run_with_commit\`:
  - Top-level "⚠️ The closure MUST call \`ctx.commit().await\` on every successful path" block.
  - Pointer to \`run\` as the safer default.
  - Three example pairs: correct usage, the silent-rollback footgun (clearly labeled BUG), and the intended conditional-commit scenario.
- Bump entity-core 0.5.2 → 0.5.3 so the new docs reach docs.rs.

No runtime behavior change.

## Test plan

- [x] \`cargo doc --all-features --no-deps\` — builds clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo +nightly fmt --all -- --check\` — clean
- [x] \`cargo check --all-features\` — clean
- [ ] Full CI green incl. Codecov before merge