### PR TITLE
fix(ci): enrich release notes with author/PR details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,14 +516,21 @@ jobs:
           LATEST_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
           echo "Latest tag: ${LATEST_TAG:-none}"
 
+          # Pass --github-token so cliff can resolve commit.remote.username
+          # and commit.remote.pr_number, which the cliff.toml template uses
+          # to render author and PR links in each entry.
           if [ -n "$LATEST_TAG" ]; then
-            NOTES=$(git cliff --config cliff.toml --unreleased --strip header --tag "$TAG" 2>/dev/null || echo "")
+            NOTES=$(git cliff --config cliff.toml --github-token "$GITHUB_TOKEN" --unreleased --strip header --tag "$TAG" 2>/dev/null || echo "")
           else
-            NOTES=$(git cliff --config cliff.toml --strip header --tag "$TAG" 2>/dev/null || echo "")
+            NOTES=$(git cliff --config cliff.toml --github-token "$GITHUB_TOKEN" --strip header --tag "$TAG" 2>/dev/null || echo "")
           fi
 
-          # Fallback: extract from merged PR if changelog is empty
-          if [ -z "$NOTES" ] || [ "$(echo "$NOTES" | wc -w)" -lt 10 ]; then
+          # Fallback: extract from merged PRs if cliff produced nothing
+          # substantial. The previous threshold of 10 words considered a
+          # template skeleton (heading + "Full Changelog" link, ~14 words)
+          # to be a successful render; bump to 30 so an empty body still
+          # triggers the fallback.
+          if [ -z "$NOTES" ] || [ "$(echo "$NOTES" | wc -w)" -lt 30 ]; then
             echo "git-cliff output empty, extracting from merged PRs..."
 
             # Find merged PRs since last tag

--- a/cliff.toml
+++ b/cliff.toml
@@ -69,7 +69,14 @@ conventional_commits = true
 filter_unconventional = true
 split_commits = false
 commit_preprocessors = [
-    # Link issue references
+    # Strip the leading `#NN ` issue prefix this repo uses on commit subjects
+    # (e.g. `#112 docs(scope): …`) so the remainder parses as a clean
+    # conventional commit. The PR number is still recovered by cliff from the
+    # squash-merge metadata (`commit.remote.pr_number`) and linked in the
+    # template; the issue number stays referenced via `Closes #NN` in the
+    # commit body.
+    { pattern = '^#(\d+)\s+', replace = "" },
+    # Link inline issue references like `(close #123)` to the issue page.
     { pattern = '\((\w+)\s?\#([0-9]+)\)', replace = "([#${2}](https://github.com/RAprogramm/entity-derive/issues/${2}))" },
 ]
 commit_parsers = [

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes #114

## Summary

GitHub releases since v0.7.0 contained only a heading and a "Full Changelog" compare link — no commit list, no author attribution, no PR links. Two issues kept the data from reaching the (otherwise-correct) cliff template.

### Fix 1 — pass \`--github-token\` to git-cliff release-notes step

The "Generate release notes" step in \`ci.yml\` ran \`git cliff\` without a token. Without it, \`commit.remote.username\` / \`commit.remote.pr_number\` are empty and the template renders empty per-commit lines.

### Fix 2 — strip the \`#NN \` prefix on commit subjects before cliff parses

This repo's commit convention starts subjects with \`#NN type(scope): …\`. \`filter_unconventional = true\` was making cliff drop them as non-conventional (visible in \`-vv\` output as "1 commit(s) were skipped due to parse error(s)"). New \`commit_preprocessor\` strips the leading \`#NN \` so the rest parses cleanly. PR/issue links are preserved via:
- squash-merge metadata (cliff fills \`commit.remote.pr_number\`)
- \`Closes #NN\` lines in commit bodies (untouched by the preprocessor)

### Fix 3 — bump the fallback word threshold

\`if [ "$(echo "$NOTES" | wc -w)" -lt 10 ]\` considered a skeleton (heading + compare link, ~14 words) a success and skipped the PR-extraction fallback. Bumped to 30.

## Local verification

\`\`\`
git cliff --config cliff.toml --github-token "\$TOKEN" --strip header v0.6.0..HEAD
\`\`\`

Sample output:

\`\`\`
### 🐛 Bug Fixes

- **transactions:** Deprecate generated with_*() no-op builder + release 0.7.2 (#111) ([159876d](.../commit/159876d3…)) by [@RAprogramm](https://github.com/RAprogramm) in [#111](.../pull/111)
- **map:** Emit compile_error for invalid expr and nested-meta failures (#109) ([c6c5557](.../commit/c6c55572…)) by [@RAprogramm](https://github.com/RAprogramm) in [#109](.../pull/109)
\`\`\`

Each line carries scope, short hash + commit URL, \`@author\` link, and \`#PR\` link.

## Release bump

Bumping \`entity-core\` 0.5.3 → 0.5.4 so the next release pipeline actually runs and exercises the fixed templates end-to-end.

## Test plan

- [x] \`cargo check --all-features\` — clean
- [x] Local cliff dry-run on \`v0.6.0..HEAD\` — every entry has author, hash, PR links
- [ ] Full CI green incl. Codecov before merge
- [ ] After merge: confirm the v0.5.4 (or whatever next-tag-is) GitHub Release body is enriched