### PR TITLE
chore(release): 0.7.3 to validate enriched release notes

### DIFF
--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.7.2"
+version = "0.7.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes #116

## Summary

Pure version bump: \`entity-derive\` 0.7.2 → 0.7.3. No code changes. Validates the release-notes fix from PR #115 end-to-end on a real GitHub release.

## Why

PR #115 fixed the release-notes generator (\`--github-token\` to git-cliff + strip-\`#NN\`-prefix preprocessor). The fix shipped in main when \`entity-core\` 0.5.4 published, but the pipeline tags releases off \`crates/entity-derive/Cargo.toml\`'s version. That version was still 0.7.2, so no new tag/release was created — the enriched notes were never rendered on a real release.

## Acceptance

After merge, the v0.7.3 GitHub release body shows commits #113 and #115 with author + PR links.

## Test plan

- [x] \`cargo check --all-features\` — clean
- [ ] Full CI green incl. Codecov
- [ ] After merge: v0.7.3 release body lists commits with hash, author, PR links