### PR TITLE
feat: opt-in tracing instrumentation on generated entity methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ license = "MIT"
 repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
-entity-core = { path = "crates/entity-core", version = "0.5" }
-entity-derive = { path = "crates/entity-derive", version = "0.7" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.5" }
+entity-core = { path = "crates/entity-core", version = "0.6" }
+entity-derive = { path = "crates/entity-derive", version = "0.8" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.6" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.5.4"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -21,6 +21,7 @@ postgres = ["sqlx"]
 clickhouse = []
 mongodb = []
 streams = ["serde", "serde_json", "futures"]
+tracing = ["dep:tracing"]
 
 [dependencies]
 async-trait = "0.1"
@@ -30,6 +31,7 @@ sqlx = { version = "0.8", optional = true, default-features = false, features = 
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 futures = { version = "0.3", optional = true }
+tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/entity-core/src/transaction.rs
+++ b/crates/entity-core/src/transaction.rs
@@ -300,10 +300,14 @@ impl Transaction<'_, sqlx::PgPool> {
     /// # Errors
     ///
     /// Propagates any error from the closure, from `begin`, or from `commit`.
+    #[cfg_attr(
+        feature = "tracing",
+        ::tracing::instrument(skip_all, fields(op = "tx.run"), err(Debug))
+    )]
     pub async fn run<F, T, E>(self, f: F) -> Result<T, E>
     where
         F: AsyncFnOnce(&mut TransactionContext) -> Result<T, E>,
-        E: From<sqlx::Error>
+        E: From<sqlx::Error> + core::fmt::Debug
     {
         let tx = self.pool.begin().await.map_err(E::from)?;
         let mut ctx = TransactionContext::new(tx);
@@ -377,11 +381,15 @@ impl Transaction<'_, sqlx::PgPool> {
     /// # Errors
     ///
     /// Propagates any error from the closure or database transaction.
+    #[cfg_attr(
+        feature = "tracing",
+        ::tracing::instrument(skip_all, fields(op = "tx.run_with_commit"), err(Debug))
+    )]
     pub async fn run_with_commit<F, Fut, T, E>(self, f: F) -> Result<T, E>
     where
         F: FnOnce(TransactionContext) -> Fut + Send,
         Fut: Future<Output = Result<T, E>> + Send,
-        E: From<sqlx::Error>
+        E: From<sqlx::Error> + core::fmt::Debug
     {
         let tx = self.pool.begin().await.map_err(E::from)?;
         let ctx = TransactionContext::new(tx);

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -32,7 +32,7 @@ use super::{
     context::Context,
     helpers::{insert_bindings, update_bindings}
 };
-use crate::entity::parse::ReturningMode;
+use crate::{entity::parse::ReturningMode, utils::tracing::instrument};
 
 impl Context<'_> {
     /// Generate the `create` method implementation.
@@ -67,10 +67,13 @@ impl Context<'_> {
         } = self;
         let bindings = insert_bindings(entity.all_fields());
 
+        let span = instrument(&entity_name.to_string(), "create");
+
         match returning {
             ReturningMode::Full => {
                 let notify = self.notify_created();
                 quote! {
+                    #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
@@ -89,6 +92,7 @@ impl Context<'_> {
                 let id_name = self.id_name;
                 let notify = self.notify_created();
                 quote! {
+                    #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
@@ -103,6 +107,7 @@ impl Context<'_> {
             ReturningMode::None => {
                 let notify = self.notify_created();
                 quote! {
+                    #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
@@ -118,6 +123,7 @@ impl Context<'_> {
                 let returning_cols = columns.join(", ");
                 let notify = self.notify_created();
                 quote! {
+                    #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
@@ -160,7 +166,10 @@ impl Context<'_> {
             ""
         };
 
+        let span = instrument(&entity_name.to_string(), "find_by_id");
+
         quote! {
+            #span
             async fn find_by_id(&self, id: #id_type) -> Result<Option<#entity_name>, Self::Error> {
                 let row: Option<#row_name> = sqlx::query_as(
                     &format!("SELECT {} FROM {} WHERE {} = {}{}", #columns_str, #table, stringify!(#id_name), #placeholder, #deleted_filter)
@@ -211,10 +220,12 @@ impl Context<'_> {
 
         let fetch_old = self.fetch_old_for_update();
         let notify = self.notify_updated();
+        let span = instrument(&entity_name.to_string(), "update");
 
         match returning {
             ReturningMode::Full => {
                 quote! {
+                    #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
                         #fetch_old
                         let row: #row_name = sqlx::query_as(
@@ -231,6 +242,7 @@ impl Context<'_> {
             }
             ReturningMode::Id | ReturningMode::None => {
                 quote! {
+                    #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
                         #fetch_old
                         sqlx::query(&format!("UPDATE {} SET {} WHERE {} = {}", #table, #set_clause, stringify!(#id_name), #where_placeholder))
@@ -246,6 +258,7 @@ impl Context<'_> {
             ReturningMode::Custom(columns) => {
                 let returning_cols = columns.join(", ");
                 quote! {
+                    #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
                         #fetch_old
                         sqlx::query(&format!("UPDATE {} SET {} WHERE {} = {} RETURNING {}", #table, #set_clause, stringify!(#id_name), #where_placeholder, #returning_cols))
@@ -277,6 +290,7 @@ impl Context<'_> {
     /// ```
     pub fn delete_method(&self) -> TokenStream {
         let Self {
+            entity_name,
             table,
             id_name,
             id_type,
@@ -288,7 +302,9 @@ impl Context<'_> {
 
         if *soft_delete {
             let notify = self.notify_soft_deleted();
+            let span = instrument(&entity_name.to_string(), "soft_delete");
             quote! {
+                #span
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
                     let result = sqlx::query(&format!(
                         "UPDATE {} SET deleted_at = NOW() WHERE {} = {} AND deleted_at IS NULL",
@@ -303,7 +319,9 @@ impl Context<'_> {
             }
         } else {
             let notify = self.notify_hard_deleted();
+            let span = instrument(&entity_name.to_string(), "delete");
             quote! {
+                #span
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
                     let result = sqlx::query(&format!("DELETE FROM {} WHERE {} = {}", #table, stringify!(#id_name), #placeholder))
                         .bind(&id).execute(self).await?;
@@ -346,7 +364,10 @@ impl Context<'_> {
             ""
         };
 
+        let span = instrument(&entity_name.to_string(), "list");
+
         quote! {
+            #span
             async fn list(&self, limit: i64, offset: i64) -> Result<Vec<#entity_name>, Self::Error> {
                 let rows: Vec<#row_name> = sqlx::query_as(
                     &format!("SELECT {} FROM {} {}ORDER BY {} DESC LIMIT {} OFFSET {}",

--- a/crates/entity-derive-impl/src/entity/sql/postgres/lookup.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/lookup.rs
@@ -50,7 +50,10 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::context::Context;
-use crate::entity::parse::{FieldDef, SqlLevel};
+use crate::{
+    entity::parse::{FieldDef, SqlLevel},
+    utils::tracing::instrument
+};
 
 impl Context<'_> {
     /// Generate all lookup method implementations.
@@ -116,8 +119,11 @@ impl Context<'_> {
         let field_type = field.ty();
         let method_name = format_ident!("find_by_{}", field_name_str);
         let placeholder = dialect.placeholder(1);
+        let op = format!("find_by_{field_name_str}");
+        let span = instrument(&entity_name.to_string(), &op);
 
         quote! {
+            #span
             async fn #method_name(&self, #field_name: #field_type) -> Result<Option<#entity_name>, Self::Error> {
                 let row: Option<#row_name> = sqlx::query_as(
                     &format!("SELECT * FROM {} WHERE {} = {}", #table, stringify!(#field_name), #placeholder)
@@ -136,6 +142,7 @@ impl Context<'_> {
     /// ```
     fn exists_by_method(&self, field: &FieldDef) -> TokenStream {
         let Self {
+            entity_name,
             table,
             dialect,
             ..
@@ -146,8 +153,11 @@ impl Context<'_> {
         let field_type = field.ty();
         let method_name = format_ident!("exists_by_{}", field_name_str);
         let placeholder = dialect.placeholder(1);
+        let op = format!("exists_by_{field_name_str}");
+        let span = instrument(&entity_name.to_string(), &op);
 
         quote! {
+            #span
             async fn #method_name(&self, #field_name: #field_type) -> Result<bool, Self::Error> {
                 let exists: bool = sqlx::query_scalar(
                     &format!("SELECT EXISTS(SELECT 1 FROM {} WHERE {} = {})", #table, stringify!(#field_name), #placeholder)

--- a/crates/entity-derive-impl/src/entity/sql/postgres/projections.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/projections.rs
@@ -24,7 +24,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::context::Context;
-use crate::entity::parse::ProjectionDef;
+use crate::{entity::parse::ProjectionDef, utils::tracing::instrument};
 
 impl Context<'_> {
     /// Generate all projection methods.
@@ -67,7 +67,11 @@ impl Context<'_> {
             .collect::<Vec<_>>()
             .join(", ");
 
+        let op = format!("find_by_id_{proj_snake}");
+        let span = instrument(&entity_name.to_string(), &op);
+
         quote! {
+            #span
             async fn #method_name(&self, id: #id_type) -> Result<Option<#proj_type>, Self::Error> {
                 let row = sqlx::query_as::<_, #proj_type>(
                     &format!("SELECT {} FROM {} WHERE {} = {}", #columns_str, #table, stringify!(#id_name), #placeholder)

--- a/crates/entity-derive-impl/src/entity/sql/postgres/save.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/save.rs
@@ -41,7 +41,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::context::Context;
-use crate::entity::parse::SqlLevel;
+use crate::{entity::parse::SqlLevel, utils::tracing::instrument};
 
 impl Context<'_> {
     /// Generate the `save` method implementation for aggregate roots.
@@ -73,7 +73,10 @@ impl Context<'_> {
         let bindings = super::helpers::insert_bindings(self.entity.all_fields());
         let error_type = self.entity.error_type();
 
+        let span = instrument(&entity_name.to_string(), "save");
+
         quote! {
+            #span
             async fn save(&self, new: #new_name) -> Result<#entity_name, #error_type> {
                 let mut tx = self.begin().await?;
 

--- a/crates/entity-derive-impl/src/entity/streams/subscriber.rs
+++ b/crates/entity-derive-impl/src/entity/streams/subscriber.rs
@@ -8,15 +8,22 @@
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
-use crate::{entity::parse::EntityDef, utils::marker};
+use crate::{
+    entity::parse::EntityDef,
+    utils::{marker, tracing::instrument}
+};
 
 /// Generate the subscriber struct and implementation.
 pub fn generate(entity: &EntityDef) -> TokenStream {
     let vis = &entity.vis;
     let entity_name = entity.name();
+    let entity_name_str = entity_name.to_string();
     let subscriber_name = format_ident!("{}Subscriber", entity_name);
     let event_name = format_ident!("{}Event", entity_name);
     let marker = marker::generated();
+    let new_span = instrument(&entity_name_str, "stream.subscribe");
+    let recv_span = instrument(&entity_name_str, "stream.recv");
+    let try_recv_span = instrument(&entity_name_str, "stream.try_recv");
 
     let doc = format!(
         "Subscriber for real-time [`{entity_name}`] change events.\n\n\
@@ -34,6 +41,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             /// Create a new subscriber connected to the database pool.
             ///
             /// Automatically subscribes to the entity's notification channel.
+            #new_span
             pub async fn new(pool: &::sqlx::PgPool) -> Result<Self, ::sqlx::Error> {
                 let mut listener = ::sqlx::postgres::PgListener::connect_with(pool).await?;
                 listener.listen(#entity_name::CHANNEL).await?;
@@ -43,6 +51,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             /// Receive the next event.
             ///
             /// Blocks until an event is available.
+            #recv_span
             pub async fn recv(
                 &mut self,
             ) -> Result<#event_name, ::entity_core::stream::StreamError<::sqlx::Error>> {
@@ -59,6 +68,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             /// Try to receive an event without blocking.
             ///
             /// Returns `None` if no event is immediately available.
+            #try_recv_span
             pub async fn try_recv(
                 &mut self,
             ) -> Result<Option<#event_name>, ::entity_core::stream::StreamError<::sqlx::Error>> {

--- a/crates/entity-derive-impl/src/entity/transaction.rs
+++ b/crates/entity-derive-impl/src/entity/transaction.rs
@@ -31,7 +31,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use super::{parse::EntityDef, sql::postgres::Context};
-use crate::utils::marker;
+use crate::utils::{marker, tracing::instrument};
 
 /// Generate all transaction-related code for an entity.
 ///
@@ -80,11 +80,14 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
         ""
     };
 
+    let entity_name_str = entity_name.to_string();
+    let create_span = instrument(&entity_name_str, "tx.create");
     let create_method = if entity.create_fields().is_empty() {
         TokenStream::new()
     } else {
         quote! {
             /// Create a new entity within the transaction.
+            #create_span
             pub async fn create(
                 &mut self,
                 dto: #create_dto
@@ -101,6 +104,7 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
         }
     };
 
+    let update_span = instrument(&entity_name_str, "tx.update");
     let update_method = if entity.update_fields().is_empty() {
         TokenStream::new()
     } else {
@@ -113,6 +117,7 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
 
         quote! {
             /// Update an entity within the transaction.
+            #update_span
             pub async fn update(
                 &mut self,
                 id: #id_type,
@@ -148,6 +153,15 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
         }
     };
 
+    let find_span = instrument(&entity_name_str, "tx.find_by_id");
+    let delete_op = if soft_delete {
+        "tx.soft_delete"
+    } else {
+        "tx.delete"
+    };
+    let delete_span = instrument(&entity_name_str, delete_op);
+    let list_span = instrument(&entity_name_str, "tx.list");
+
     quote! {
         #marker
         /// Transaction repository adapter for #entity_name.
@@ -168,6 +182,7 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
             #create_method
 
             /// Find an entity by ID within the transaction.
+            #find_span
             pub async fn find_by_id(
                 &mut self,
                 id: #id_type
@@ -182,6 +197,7 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
             #update_method
 
             /// Delete an entity within the transaction.
+            #delete_span
             pub async fn delete(
                 &mut self,
                 id: #id_type
@@ -190,6 +206,7 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
             }
 
             /// List entities within the transaction.
+            #list_span
             pub async fn list(
                 &mut self,
                 limit: i64,

--- a/crates/entity-derive-impl/src/utils.rs
+++ b/crates/entity-derive-impl/src/utils.rs
@@ -10,7 +10,9 @@
 //! - [`docs`] — Documentation extraction from attributes
 //! - [`fields`] — Field assignment generation for `From` implementations
 //! - [`marker`] — Generated code marker comments
+//! - [`tracing`] — Optional `#[tracing::instrument]` attribute emission
 
 pub mod docs;
 pub mod fields;
 pub mod marker;
+pub mod tracing;

--- a/crates/entity-derive-impl/src/utils/tracing.rs
+++ b/crates/entity-derive-impl/src/utils/tracing.rs
@@ -1,0 +1,121 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Optional `tracing` instrumentation for generated entity methods.
+//!
+//! Emits a `#[cfg_attr(feature = "tracing", ::tracing::instrument(...))]`
+//! attribute that wraps generated async methods. The attribute is gated
+//! on the consumer crate's `tracing` feature, so users who don't depend
+//! on `tracing` see zero overhead.
+//!
+//! # Generated Span
+//!
+//! Each method is wrapped with a span carrying two fields:
+//!
+//! - `entity = "<EntityName>"` — the entity struct name
+//! - `op = "<operation>"` — a stable label per generated method (e.g.
+//!   `"create"`, `"find_by_id"`, `"find_by_email"`)
+//!
+//! `skip_all` hides parameter values (DTOs, pool handles) from the span.
+//! `err` automatically emits an `ERROR` event when the method returns
+//! `Err`, with the formatted error in the message.
+//!
+//! # Example Output
+//!
+//! ```rust,ignore
+//! #[cfg_attr(
+//!     feature = "tracing",
+//!     ::tracing::instrument(
+//!         skip_all,
+//!         fields(entity = "User", op = "create"),
+//!         err,
+//!     )
+//! )]
+//! pub async fn create(&self, dto: CreateUserRequest) -> Result<User, sqlx::Error> { … }
+//! ```
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+/// Generate a `#[cfg_attr(feature = "tracing", …instrument…)]` attribute.
+///
+/// # Arguments
+///
+/// * `entity_name` — entity struct name, e.g. `"User"`. Goes into the `entity =
+///   …` span field as a string literal.
+/// * `op` — short stable operation label, e.g. `"create"` or `"find_by_email"`.
+///   Goes into the `op = …` span field.
+///
+/// # Returns
+///
+/// A `TokenStream` ready to splice in front of an `async fn`. If the
+/// consumer crate does not enable the `tracing` feature, the attribute
+/// expands to nothing.
+#[must_use]
+pub fn instrument(entity_name: &str, op: &str) -> TokenStream {
+    quote! {
+        #[cfg_attr(
+            feature = "tracing",
+            ::tracing::instrument(
+                skip_all,
+                fields(entity = #entity_name, op = #op),
+                err(Debug)
+            )
+        )]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn emits_cfg_attr_gate() {
+        let tokens = instrument("User", "create").to_string();
+        assert!(
+            tokens.contains("cfg_attr"),
+            "must be feature-gated: {tokens}"
+        );
+        assert!(
+            tokens.contains("feature = \"tracing\""),
+            "wrong gate: {tokens}"
+        );
+    }
+
+    #[test]
+    fn carries_entity_and_op_fields() {
+        let tokens = instrument("User", "find_by_email").to_string();
+        assert!(
+            tokens.contains("entity = \"User\""),
+            "entity field missing: {tokens}"
+        );
+        assert!(
+            tokens.contains("op = \"find_by_email\""),
+            "op field missing: {tokens}"
+        );
+    }
+
+    #[test]
+    fn enables_err_event() {
+        let tokens = instrument("User", "create").to_string();
+        assert!(tokens.contains("err"), "err event missing: {tokens}");
+    }
+
+    #[test]
+    fn skips_all_args_by_default() {
+        let tokens = instrument("User", "create").to_string();
+        assert!(tokens.contains("skip_all"), "skip_all missing: {tokens}");
+    }
+
+    #[test]
+    fn references_tracing_via_absolute_path() {
+        // `::tracing::instrument` resolves from the consumer crate's root,
+        // not from entity-derive-impl. This way the user's Cargo.toml
+        // owns the `tracing` dep.
+        let tokens = instrument("User", "create").to_string();
+        assert!(
+            tokens.contains(":: tracing :: instrument"),
+            "must use absolute path: {tokens}"
+        );
+    }
+}

--- a/crates/entity-derive-impl/src/utils/tracing.rs
+++ b/crates/entity-derive-impl/src/utils/tracing.rs
@@ -31,7 +31,7 @@
 //!         err,
 //!     )
 //! )]
-//! pub async fn create(&self, dto: CreateUserRequest) -> Result<User, sqlx::Error> { … }
+//! pub async fn create(&self, dto: CreateUserRequest) -> Result<User, sqlx::Error> { /* ... */ }
 //! ```
 
 use proc_macro2::TokenStream;

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.7.3"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -23,10 +23,14 @@ mongodb = ["entity-core/mongodb"]
 streams = ["entity-core/streams"]
 api = []
 validate = []
+# Opt-in: emit `#[tracing::instrument]` on every generated async method.
+# Users who enable this must also depend on `tracing` directly so the
+# generated `::tracing::instrument` resolves.
+tracing = ["entity-core/tracing"]
 
 [dependencies]
-entity-core = { path = "../entity-core", version = "0.5" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.5" }
+entity-core = { path = "../entity-core", version = "0.6" }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.6" }
 
 [dev-dependencies]
 trybuild = "1"
@@ -43,6 +47,7 @@ sqlx = { version = "0.8", features = [
   "derive",
 ] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tracing = "0.1"
 utoipa = { version = "5", features = ["chrono", "uuid"] }
 validator = { version = "0.20", features = ["derive"] }
 

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/commands/Cargo.toml
+++ b/examples/commands/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/filtering/Cargo.toml
+++ b/examples/filtering/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/full-app/Cargo.toml
+++ b/examples/full-app/Cargo.toml
@@ -13,6 +13,9 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+# Acknowledge the feature gate that entity-derive emits on generated
+# methods (silences `unexpected cfg condition value` warnings).
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api", "streams"] }

--- a/examples/hooks/Cargo.toml
+++ b/examples/hooks/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/relations/Cargo.toml
+++ b/examples/relations/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/soft-delete/Cargo.toml
+++ b/examples/soft-delete/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }

--- a/examples/streams/Cargo.toml
+++ b/examples/streams/Cargo.toml
@@ -13,6 +13,7 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api", "streams"] }

--- a/examples/transactions/Cargo.toml
+++ b/examples/transactions/Cargo.toml
@@ -13,6 +13,11 @@ default = ["postgres", "api"]
 postgres = []
 api = []
 validate = []
+# Acknowledge the feature gate that entity-derive emits on generated
+# methods. We don't actually enable tracing instrumentation here, but
+# declaring the feature silences `unexpected cfg condition value`
+# warnings introduced by the cfg-check tightening in Rust 1.80+.
+tracing = []
 
 [dependencies]
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }


### PR DESCRIPTION
Closes #118

## Summary

Make logger output pinpoint *which entity* failed without per-call boilerplate. Every generated async method (CRUD on \`Repository\`, transaction adapter, projection lookups, save, stream subscriber) is now wrapped with:

\`\`\`rust
#[cfg_attr(
    feature = "tracing",
    ::tracing::instrument(
        skip_all,
        fields(entity = "User", op = "create"),
        err(Debug),
    )
)]
\`\`\`

Opt-in via Cargo feature → zero cost when off, identical bits to today.

## What's covered

| Source | Methods | Op label |
|---|---|---|
| \`sql/postgres/crud.rs\` | create / find_by_id / update / delete / list | \`create\` / \`find_by_id\` / \`update\` / \`delete\` (or \`soft_delete\`) / \`list\` |
| \`sql/postgres/lookup.rs\` | find_by_<field> / exists_by_<field> | dynamic |
| \`sql/postgres/projections.rs\` | find_by_id_<projection> | dynamic |
| \`sql/postgres/save.rs\` | save (aggregate root) | \`save\` |
| \`transaction.rs\` (proc-macro) | tx.create / tx.find_by_id / tx.update / tx.delete / tx.list | \`tx.<op>\` |
| \`streams/subscriber.rs\` | new / recv / try_recv | \`stream.subscribe\` / \`stream.recv\` / \`stream.try_recv\` |
| \`entity-core::Transaction\` (manual) | run / run_with_commit | \`tx.run\` / \`tx.run_with_commit\` |

## Helper

\`crates/entity-derive-impl/src/utils/tracing.rs\` — single source for the attribute emission. 5 unit tests lock the shape:

- emits \`#[cfg_attr(feature = "tracing", …)]\`
- carries \`entity\` and \`op\` fields
- enables \`err(Debug)\`
- uses \`skip_all\`
- references \`::tracing::instrument\` via absolute path

## Cargo wiring

- \`entity-core\` — feature \`tracing = ["dep:tracing"]\` + optional \`tracing\` dep.
- \`entity-derive\` — feature \`tracing = ["entity-core/tracing"]\`. Added \`tracing\` as dev-dep so the test crate compiles with \`--all-features\`.
- All 10 example crates declare a no-op \`tracing = []\` feature to silence \`unexpected cfg condition value: "tracing"\` warnings under Rust 1.80+.

## Version bump (new feature → minor)

| Crate | Old | New |
|---|---|---|
| entity-core | 0.5.4 | 0.6.0 |
| entity-derive-impl | 0.5.2 | 0.6.0 |
| entity-derive | 0.7.3 | 0.8.0 |

## Breaking change in entity-core

\`Transaction::run\` and \`run_with_commit\` gain a \`core::fmt::Debug\` bound on the closure's error type \`E\`. \`sqlx::Error\` and all standard error types already satisfy it, so most users won't notice — but technically it is breaking. Justifies the minor bump from 0.5 to 0.6.

## Usage

\`\`\`toml
[dependencies]
entity-derive = { version = "0.8", features = ["tracing"] }
tracing = "0.1"
tracing-subscriber = "0.3"
\`\`\`

Initialize a subscriber and you get logs like:

\`\`\`
ERROR entity.User.create: error=database error: duplicate key value violates unique constraint
  in entity.User.create with entity="User" op="create"
\`\`\`

## Test plan

- [x] \`cargo test --all-features\` — 543 + 9 + 45 + 2 tests pass
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo +nightly fmt --all -- --check\` — clean
- [x] All 10 examples compile cleanly without deprecation/cfg warnings
- [ ] Codecov green before merge