### PR TITLE
chore(release): 0.8.1 — ship refreshed README

### DIFF
--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.8.0"
+version = "0.8.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes #122

## Summary

Pure version bump: \`entity-derive\` 0.8.0 → 0.8.1. Triggers publication of a fresh tarball so [crates.io](https://crates.io/crates/entity-derive) and [docs.rs](https://docs.rs/entity-derive) render the README refreshed in #121.

| Crate | Old | New |
|---|---|---|
| entity-derive | 0.8.0 | 0.8.1 |

\`entity-core\` (0.6.0) and \`entity-derive-impl\` (0.6.0) are unchanged.

## Test plan

- [x] \`cargo check --all-features\` — clean
- [ ] CI green
- [ ] After merge: https://crates.io/crates/entity-derive shows the new README