### PR TITLE
fix(atomicity): wrap streams CRUD + pg_notify in one transaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 With a subscriber initialized, a failed `User::create` surfaces as:
 
-```
+```text
 ERROR entity.User.create: error=database error: duplicate key value violates unique constraint
   in entity.User.create with entity="User" op="create"
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.6.0"
+version = "0.6.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -34,6 +34,29 @@ use super::{
 };
 use crate::{entity::parse::ReturningMode, utils::tracing::instrument};
 
+/// Return the `(open, close, executor)` token fragments that bracket
+/// streams-aware DML.
+///
+/// - When `streams` is `true`, the caller wraps its work in a transaction so
+///   the DML and the subsequent `pg_notify` participate in one atomic unit.
+///   `open` opens the transaction, `close` commits it, and `executor` is `&mut
+///   *tx` (the right argument for `.execute` / `.fetch_one` on a transaction
+///   handle).
+/// - When `streams` is `false`, the wrapping fragments are empty and the
+///   executor is `self`, keeping the generated method a single SQL round-trip
+///   with no behavior change vs. earlier releases.
+fn tx_wrapping(streams: bool) -> (TokenStream, TokenStream, TokenStream) {
+    if streams {
+        (
+            quote! { let mut tx = self.begin().await?; },
+            quote! { tx.commit().await?; },
+            quote! { &mut *tx }
+        )
+    } else {
+        (TokenStream::new(), TokenStream::new(), quote! { self })
+    }
+}
+
 impl Context<'_> {
     /// Generate the `create` method implementation.
     ///
@@ -63,74 +86,86 @@ impl Context<'_> {
             placeholders_str,
             entity,
             returning,
+            streams,
             ..
         } = self;
         let bindings = insert_bindings(entity.all_fields());
 
         let span = instrument(&entity_name.to_string(), "create");
+        // When `streams` is on, the DML and the `pg_notify` must commit as
+        // one unit: Postgres only broadcasts `NOTIFY` on commit and discards
+        // it on rollback, so wrapping both in a transaction eliminates the
+        // crash-between-commit-and-notify window. Non-streams entities keep
+        // the single-statement fast path.
+        let (tx_open, tx_close, executor) = tx_wrapping(*streams);
+        let notify = self.notify_created();
 
         match returning {
             ReturningMode::Full => {
-                let notify = self.notify_created();
                 quote! {
                     #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
+                        #tx_open
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
                         let row: #row_name = sqlx::query_as(
                             concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ") RETURNING *")
                         )
                             #(#bindings)*
-                            .fetch_one(self).await?;
+                            .fetch_one(#executor).await?;
                         let entity = #entity_name::from(row);
                         #notify
+                        #tx_close
                         Ok(entity)
                     }
                 }
             }
             ReturningMode::Id => {
                 let id_name = self.id_name;
-                let notify = self.notify_created();
                 quote! {
                     #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
+                        #tx_open
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
                         sqlx::query(concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ") RETURNING ", stringify!(#id_name)))
                             #(#bindings)*
-                            .execute(self).await?;
+                            .execute(#executor).await?;
                         #notify
+                        #tx_close
                         Ok(entity)
                     }
                 }
             }
             ReturningMode::None => {
-                let notify = self.notify_created();
                 quote! {
                     #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
+                        #tx_open
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
                         sqlx::query(concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ")"))
                             #(#bindings)*
-                            .execute(self).await?;
+                            .execute(#executor).await?;
                         #notify
+                        #tx_close
                         Ok(entity)
                     }
                 }
             }
             ReturningMode::Custom(columns) => {
                 let returning_cols = columns.join(", ");
-                let notify = self.notify_created();
                 quote! {
                     #span
                     async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error> {
+                        #tx_open
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
                         sqlx::query(&format!("INSERT INTO {} ({}) VALUES ({}) RETURNING {}", #table, #columns_str, #placeholders_str, #returning_cols))
                             #(#bindings)*
-                            .execute(self).await?;
+                            .execute(#executor).await?;
                         #notify
+                        #tx_close
                         Ok(entity)
                     }
                 }
@@ -209,6 +244,7 @@ impl Context<'_> {
             dialect,
             trait_name,
             returning,
+            streams,
             ..
         } = self;
 
@@ -218,25 +254,50 @@ impl Context<'_> {
         let where_placeholder = dialect.placeholder(update_fields.len() + 1);
         let bindings = update_bindings(&update_fields);
 
-        let fetch_old = self.fetch_old_for_update();
-        let notify = self.notify_updated();
         let span = instrument(&entity_name.to_string(), "update");
 
+        // Streams-on path: SELECT FOR UPDATE → UPDATE RETURNING * → notify,
+        // all in one transaction. Always fetches the full row (regardless
+        // of `returning` config) because the Updated event payload requires
+        // it; a streams entity that asked for a narrower `RETURNING` clause
+        // would have to re-fetch separately anyway, defeating the optimization.
+        if *streams {
+            let fetch_old = self.fetch_old_for_update();
+            let notify = self.notify_updated();
+            return quote! {
+                #span
+                async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
+                    let mut tx = self.begin().await?;
+                    #fetch_old
+                    let row: #row_name = sqlx::query_as(
+                        &format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder)
+                    )
+                        #(#bindings)*
+                        .bind(&id)
+                        .fetch_one(&mut *tx).await?;
+                    let entity = #entity_name::from(row);
+                    #notify
+                    tx.commit().await?;
+                    Ok(entity)
+                }
+            };
+        }
+
+        // Non-streams path: keep the historical single-statement variants,
+        // honoring the entity's `returning` configuration. Notify is empty
+        // here so we don't pay for a transaction we don't need.
         match returning {
             ReturningMode::Full => {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        #fetch_old
                         let row: #row_name = sqlx::query_as(
                             &format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder)
                         )
                             #(#bindings)*
                             .bind(&id)
                             .fetch_one(self).await?;
-                        let entity = #entity_name::from(row);
-                        #notify
-                        Ok(entity)
+                        Ok(#entity_name::from(row))
                     }
                 }
             }
@@ -244,14 +305,11 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        #fetch_old
                         sqlx::query(&format!("UPDATE {} SET {} WHERE {} = {}", #table, #set_clause, stringify!(#id_name), #where_placeholder))
                             #(#bindings)*
                             .bind(&id)
                             .execute(self).await?;
-                        let entity = <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)?;
-                        #notify
-                        Ok(entity)
+                        <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)
                     }
                 }
             }
@@ -260,14 +318,11 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        #fetch_old
                         sqlx::query(&format!("UPDATE {} SET {} WHERE {} = {} RETURNING {}", #table, #set_clause, stringify!(#id_name), #where_placeholder, #returning_cols))
                             #(#bindings)*
                             .bind(&id)
                             .execute(self).await?;
-                        let entity = <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)?;
-                        #notify
-                        Ok(entity)
+                        <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)
                     }
                 }
             }
@@ -296,9 +351,14 @@ impl Context<'_> {
             id_type,
             dialect,
             soft_delete,
+            streams,
             ..
         } = self;
         let placeholder = dialect.placeholder(1);
+        // When streams are on, wrap the DML + notify in one transaction so
+        // the event commits atomically with the deletion. Single SQL
+        // statement otherwise — no perf regression for non-streams entities.
+        let (tx_open, tx_close, executor) = tx_wrapping(*streams);
 
         if *soft_delete {
             let notify = self.notify_soft_deleted();
@@ -306,14 +366,16 @@ impl Context<'_> {
             quote! {
                 #span
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
+                    #tx_open
                     let result = sqlx::query(&format!(
                         "UPDATE {} SET deleted_at = NOW() WHERE {} = {} AND deleted_at IS NULL",
                         #table, stringify!(#id_name), #placeholder
-                    )).bind(&id).execute(self).await?;
+                    )).bind(&id).execute(#executor).await?;
                     let deleted = result.rows_affected() > 0;
                     if deleted {
                         #notify
                     }
+                    #tx_close
                     Ok(deleted)
                 }
             }
@@ -323,12 +385,14 @@ impl Context<'_> {
             quote! {
                 #span
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
+                    #tx_open
                     let result = sqlx::query(&format!("DELETE FROM {} WHERE {} = {}", #table, stringify!(#id_name), #placeholder))
-                        .bind(&id).execute(self).await?;
+                        .bind(&id).execute(#executor).await?;
                     let deleted = result.rows_affected() > 0;
                     if deleted {
                         #notify
                     }
+                    #tx_close
                     Ok(deleted)
                 }
             }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/notify.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/notify.rs
@@ -2,6 +2,19 @@
 // SPDX-License-Identifier: MIT
 
 //! Postgres NOTIFY helpers for streaming.
+//!
+//! When the `streams` feature is enabled, generated CRUD methods publish
+//! events via `pg_notify`. These helpers build the `pg_notify` SQL
+//! fragments. The executor against which the notify runs is controlled
+//! by the caller via `executor_tokens()`:
+//!
+//! - For atomic CRUD (the `update_method` / `create_method` / `delete_method`
+//!   generators wrap the whole sequence in a transaction), the executor is
+//!   `&mut *tx`, so `NOTIFY` participates in the same transaction — Postgres
+//!   only broadcasts on commit, eliminating the commit-then-crash event-loss
+//!   window.
+//! - For non-streams entities `notify_*` returns an empty `TokenStream`, so the
+//!   surrounding method stays a single SQL statement.
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -9,6 +22,17 @@ use quote::{format_ident, quote};
 use super::context::Context;
 
 impl Context<'_> {
+    /// Executor token used by `notify_*` and `fetch_old_for_update`.
+    ///
+    /// Streams-enabled CRUD wraps its DML in a `let mut tx = self.begin()...`
+    /// block, so notify must execute on the transaction handle (`&mut *tx`),
+    /// not on the pool. This keeps the notify atomic with the DML:
+    /// Postgres buffers `NOTIFY` per transaction and broadcasts only on
+    /// commit; on rollback the notify is discarded.
+    fn executor_tokens() -> TokenStream {
+        quote! { &mut *tx }
+    }
+
     /// Generate `pg_notify` call for Created event.
     pub fn notify_created(&self) -> TokenStream {
         if !self.streams {
@@ -17,6 +41,7 @@ impl Context<'_> {
 
         let entity_name = self.entity_name;
         let event_name = format_ident!("{}Event", entity_name);
+        let executor = Self::executor_tokens();
 
         quote! {
             let __event = #event_name::created(entity.clone());
@@ -25,7 +50,7 @@ impl Context<'_> {
             ::sqlx::query("SELECT pg_notify($1, $2)")
                 .bind(#entity_name::CHANNEL)
                 .bind(&__payload)
-                .execute(self)
+                .execute(#executor)
                 .await?;
         }
     }
@@ -38,6 +63,7 @@ impl Context<'_> {
 
         let entity_name = self.entity_name;
         let event_name = format_ident!("{}Event", entity_name);
+        let executor = Self::executor_tokens();
 
         quote! {
             let __event = #event_name::updated(__old_entity, entity.clone());
@@ -46,7 +72,7 @@ impl Context<'_> {
             ::sqlx::query("SELECT pg_notify($1, $2)")
                 .bind(#entity_name::CHANNEL)
                 .bind(&__payload)
-                .execute(self)
+                .execute(#executor)
                 .await?;
         }
     }
@@ -59,6 +85,7 @@ impl Context<'_> {
 
         let entity_name = self.entity_name;
         let event_name = format_ident!("{}Event", entity_name);
+        let executor = Self::executor_tokens();
 
         quote! {
             let __event = #event_name::hard_deleted(id.clone());
@@ -67,7 +94,7 @@ impl Context<'_> {
             ::sqlx::query("SELECT pg_notify($1, $2)")
                 .bind(#entity_name::CHANNEL)
                 .bind(&__payload)
-                .execute(self)
+                .execute(#executor)
                 .await?;
         }
     }
@@ -80,6 +107,7 @@ impl Context<'_> {
 
         let entity_name = self.entity_name;
         let event_name = format_ident!("{}Event", entity_name);
+        let executor = Self::executor_tokens();
 
         quote! {
             let __event = #event_name::SoftDeleted { id: id.clone() };
@@ -88,23 +116,39 @@ impl Context<'_> {
             ::sqlx::query("SELECT pg_notify($1, $2)")
                 .bind(#entity_name::CHANNEL)
                 .bind(&__payload)
-                .execute(self)
+                .execute(#executor)
                 .await?;
         }
     }
 
     /// Generate fetch for old entity before update (for Updated event).
+    ///
+    /// Reads `SELECT ... FOR UPDATE` so the row is locked for the duration
+    /// of the surrounding transaction. The old payload then matches the
+    /// state immediately preceding the UPDATE — no concurrent writer can
+    /// slip in between read and write.
     pub fn fetch_old_for_update(&self) -> TokenStream {
         if !self.streams {
             return TokenStream::new();
         }
 
-        let trait_name = &self.trait_name;
+        let entity_name = self.entity_name;
+        let row_name = &self.row_name;
+        let columns_str = &self.columns_str;
+        let table = &self.table;
+        let id_name = self.id_name;
+        let placeholder = self.dialect.placeholder(1);
+        let select_sql = format!(
+            "SELECT {columns_str} FROM {table} WHERE {id_name} = {placeholder} FOR UPDATE"
+        );
 
         quote! {
-            let __old_entity = <Self as #trait_name>::find_by_id(self, id.clone())
+            let __old_row: #row_name = ::sqlx::query_as(#select_sql)
+                .bind(&id)
+                .fetch_optional(&mut *tx)
                 .await?
                 .ok_or_else(|| ::sqlx::Error::RowNotFound)?;
+            let __old_entity = #entity_name::from(__old_row);
         }
     }
 }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.8.1"
+version = "0.8.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes #124

## Why

When the \`streams\` feature is on, generated CRUD methods previously did multiple round-trips on the pool with no coordination. Two real bugs:

1. **\`update_method\` race** — \`find_by_id\` (old payload) and \`UPDATE\` (new state) ran as separate queries on the bare pool. Concurrent UPDATE between them → Updated event describes a transition that never happened.
2. **\`create\` / \`delete\` event loss** — \`pg_notify\` was a separate round-trip *after* the DML committed. Crash / connection drop between the two silently dropped the event; row write persisted.

## Fix

Wrap the DML and the \`pg_notify\` in one \`sqlx::Transaction\` whenever \`streams\` is on:

- Postgres buffers \`NOTIFY\` per transaction and only broadcasts on commit — atomic with the DML.
- \`SELECT ... FOR UPDATE\` locks the row for the transaction's lifetime, so \`old\` and \`new\` are guaranteed adjacent.

When \`streams\` is off, the generated method stays a single SQL statement — no perf regression for non-streams entities.

## Changes

- \`sql/postgres/crud.rs::tx_wrapping(streams) -> (open, close, executor)\` helper. Streams-on returns \`let mut tx = self.begin().await?;\`, \`tx.commit().await?;\`, \`&mut *tx\`. Streams-off returns empty fragments and \`self\`.
- \`create_method\` / \`delete_method\` thread the helper through every branch (\`ReturningMode::Full | Id | None | Custom\` for create; soft and hard for delete).
- \`update_method\` splits: streams-on takes \`RETURNING *\` always (the Updated event payload needs the full row anyway); streams-off keeps the historical match on \`ReturningMode\`.
- \`notify.rs\` executor token is now \`&mut *tx\` in all four \`notify_*\`. \`fetch_old_for_update\` issues a direct \`SELECT ... FOR UPDATE\` against the transaction instead of routing through the pool-bound trait method.
- \`README.md\` codeblock for the tracing log sample is tagged \`text\` so rustdoc no longer tries to compile it (side-effect of \`lib.rs\` doing \`#![doc = include_str!("../README.md")]\`).

## Version bump

| Crate | Old | New |
|---|---|---|
| entity-derive-impl | 0.6.0 | 0.6.1 |
| entity-derive | 0.8.1 | 0.8.2 |

\`entity-core\` is unchanged.

## Test plan

- [x] \`cargo test --all-features\` — 543 + 9 + 45 + 2 lib/integration + 2 trybuild pass
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean
- [x] \`cargo +nightly fmt --all -- --check\` — clean
- [x] \`cargo check\` on examples/transactions, examples/full-app, examples/streams — clean
- [ ] CI green incl. Codecov before merge

## Out of scope (follow-up issues)

- Aggregate-root \`save\` opens its own transaction but does not emit a \`Created\` event for streams entities — separate fix.
- Hooks trait is generated but never invoked anywhere in CRUD — separate fix.