### PR TITLE
docs(hooks): clarify manual-wiring requirement; track auto-invocation in #127

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ tracing-subscriber = "0.3"
 | **Transactions** | Multi-entity atomic operations |
 | **Lifecycle Events** | `Created`, `Updated`, `Deleted` events |
 | **Real-Time Streams** | Postgres LISTEN/NOTIFY integration |
-| **Lifecycle Hooks** | `before_create`, `after_update`, etc. |
+| **Lifecycle Hook Traits** | `{Entity}Hooks` trait emitted with `before_create` / `after_update` / etc.; invocation is currently manual at your service layer (tracking auto-invocation: [#127](https://github.com/RAprogramm/entity-derive/issues/127)) |
 | **CQRS Commands** | Business-oriented command pattern |
 | **Soft Delete** | `deleted_at` timestamp support |
 | **Structured Logging** | Opt-in `tracing` feature wraps every generated async method in `#[tracing::instrument]` with `entity` + `op` fields |

--- a/crates/entity-derive-impl/src/entity/hooks.rs
+++ b/crates/entity-derive-impl/src/entity/hooks.rs
@@ -6,6 +6,25 @@
 //! Generates a hooks trait for entities with `#[entity(hooks)]`.
 //! Hooks provide before/after callbacks for CRUD operations.
 //!
+//! # ⚠️ Status: trait emitted, invocation is manual (as of 0.8.2)
+//!
+//! This module emits the `{Entity}Hooks` trait for the user to
+//! implement. **The generated repository methods do not call it
+//! automatically yet.** The generated `impl {Entity}Repository for
+//! sqlx::PgPool` lives in a different crate from any user-provided
+//! `impl …Hooks for PgPool`, and Rust's orphan rule prevents the user
+//! from wiring the two together after the fact.
+//!
+//! Until full auto-invocation lands, the supported pattern is:
+//!
+//! 1. Implement `{Entity}Hooks` on a type you own (typically a wrapper around
+//!    `PgPool` or a service struct in your application).
+//! 2. Call the hook methods explicitly at your handler / service layer around
+//!    the calls into the generated CRUD methods. See
+//!    `examples/hooks/src/main.rs` for the wiring pattern.
+//!
+//! Tracking auto-invocation: [issue #127](https://github.com/RAprogramm/entity-derive/issues/127).
+//!
 //! # Generated Code
 //!
 //! For an entity `User`, generates:
@@ -24,12 +43,14 @@
 //! }
 //! ```
 //!
-//! # Usage
+//! # Usage (manual wiring)
 //!
 //! ```rust,ignore
-//! struct MyRepo(PgPool);
+//! struct AppService {
+//!     pool: PgPool,
+//! }
 //!
-//! impl UserHooks for MyRepo {
+//! impl UserHooks for AppService {
 //!     type Error = AppError;
 //!
 //!     async fn before_create(&self, dto: &mut CreateUserRequest) -> Result<(), Self::Error> {
@@ -41,6 +62,14 @@
 //!         send_welcome_email(&user.email).await?;
 //!         Ok(())
 //!     }
+//! }
+//!
+//! // At your handler layer:
+//! async fn create_user(svc: &AppService, mut req: CreateUserRequest) -> Result<User, AppError> {
+//!     svc.before_create(&mut req).await?;
+//!     let user = <PgPool as UserRepository>::create(&svc.pool, req).await?;
+//!     svc.after_create(&user).await?;
+//!     Ok(user)
 //! }
 //! ```
 
@@ -78,11 +107,21 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         /// Implement this trait to add custom logic before/after CRUD operations.
         /// All methods have default no-op implementations.
         ///
+        /// # ⚠️ Invocation is manual
+        ///
+        /// The generated `Repository` impl on `sqlx::PgPool` does **not**
+        /// call these hooks automatically. Implement the trait on a type
+        /// you own (e.g. a service struct that wraps the pool) and call
+        /// the hook methods explicitly around your repository calls.
+        /// See `examples/hooks` and the module docs for the wiring pattern.
+        ///
+        /// Tracking auto-invocation: <https://github.com/RAprogramm/entity-derive/issues/127>.
+        ///
         /// # Error Handling
         ///
-        /// If a `before_*` hook returns an error, the operation is aborted.
-        /// If an `after_*` hook returns an error, the operation has already
-        /// completed but the error is propagated to the caller.
+        /// If a `before_*` hook returns an error, the caller should abort
+        /// the operation. If an `after_*` hook returns an error, the
+        /// operation has already completed but the error is propagated.
         #[async_trait::async_trait]
         #vis trait #hooks_trait: Send + Sync {
             /// Error type for hook operations.

--- a/examples/hooks/src/main.rs
+++ b/examples/hooks/src/main.rs
@@ -8,6 +8,16 @@
 //! - before_create, after_create
 //! - before_update, after_update
 //! - before_delete, after_delete
+//!
+//! # Manual wiring required (as of 0.8.2)
+//!
+//! The macro emits the `{Entity}Hooks` trait, but the generated
+//! `Repository` impl on `sqlx::PgPool` does NOT call it automatically.
+//! See the HTTP handlers below — each one calls `svc.before_*().await?`
+//! and `svc.after_*().await?` explicitly around the repository call.
+//! That is the supported pattern for now.
+//!
+//! Auto-invocation is tracked in <https://github.com/RAprogramm/entity-derive/issues/127>.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
Closes #126
Follow-up RFC: #127

## Summary

\`#[entity(hooks)]\` emits the \`{Entity}Hooks\` trait. The current docs imply that generated CRUD will call the hooks; it doesn't, and orphan rule prevents users from making it call them with a local impl. Honest documentation fix while #127 designs the wrapper-struct architecture.

## Changes

- \`hooks.rs\` module docs — new "Status" section + rewritten Usage example using a service struct that owns the pool (the only pattern that actually compiles).
- Generated trait rustdoc — "Invocation is manual" warning visible on hover.
- \`README.md\` feature row — soften "Lifecycle Hooks" wording and link #127.
- \`examples/hooks/src/main.rs\` — top-of-file banner naming the manual-wiring pattern.

No runtime behavior change.

## Out of scope

\`#127\` tracks the real fix: \`{Entity}Repo<H>\` wrapper that threads hook calls through every CRUD method. That's a minor-version bump and deserves a separate PR.

## Test plan

- [x] \`cargo test --all-features\` — full suite passes (no changes to generated code, just docs).
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- [x] \`cargo +nightly fmt --all -- --check\` — clean.
- [x] \`RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps\` — clean.
- [ ] CI green.