### PR TITLE
fix(commands): surface parse errors instead of silently dropping invalid #[command(...)]

### DIFF
--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.6.1"
+version = "0.6.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/parse/command/parser.rs
+++ b/crates/entity-derive-impl/src/entity/parse/command/parser.rs
@@ -71,9 +71,12 @@
 //!
 //! # Error Handling
 //!
-//! Invalid commands are silently filtered out (via `filter_map`).
-//! This allows partial compilation with some valid commands even if
-//! others have syntax errors.
+//! Parse errors from malformed `#[command(...)]` attributes are accumulated
+//! across the whole struct via [`syn::Error::combine`] and returned as a
+//! single error from [`parse_command_attrs`]. The macro then surfaces it
+//! as a `compile_error!` at the relevant attribute span, so the user sees
+//! every broken command in one compile pass instead of having them
+//! silently disappear (the old behavior — fixed in #129).
 
 use syn::{Attribute, Ident, Type};
 
@@ -81,30 +84,23 @@ use super::types::{CommandDef, CommandKindHint, CommandSource};
 
 /// Parses all `#[command(...)]` attributes from a struct.
 ///
-/// This function filters struct attributes for `#[command(...)]`, parses
-/// each one, and collects valid command definitions. Invalid commands are
-/// silently skipped to allow partial success.
+/// Iterates struct attributes, parses every `#[command(...)]`, and collects
+/// the successful definitions. Parse failures are accumulated into a single
+/// [`syn::Error`] via [`syn::Error::combine`] and returned together — the
+/// caller emits the combined error as a `compile_error!` token so the user
+/// sees every malformed attribute in one compile pass.
 ///
 /// # Arguments
 ///
 /// * `attrs` - Slice of `syn::Attribute` from the struct definition
 ///
-/// # Returns
+/// # Errors
 ///
-/// A `Vec<CommandDef>` containing all successfully parsed commands.
-/// May be empty if no valid commands are found.
-///
-/// # Parsing Process
-///
-/// ```text
-/// attrs.iter()
-///     │
-///     ├─► filter(is "command") ──► Only #[command(...)] attrs
-///     │
-///     ├─► filter_map(parse) ────► Parse each, skip errors
-///     │
-///     └─► collect() ────────────► Vec<CommandDef>
-/// ```
+/// Returns the accumulated [`syn::Error`] if any `#[command(...)]` failed
+/// to parse. Valid commands parsed before / after the failure point are
+/// dropped in this case because partial code generation with missing
+/// commands tends to produce more cryptic downstream errors than the
+/// original parse diagnostic.
 ///
 /// # Syntax Examples
 ///
@@ -133,12 +129,24 @@ use super::types::{CommandDef, CommandKindHint, CommandSource};
 /// #[command(PublicList, security = "none")]
 /// #[command(AdminDelete, requires_id, security = "admin")]
 /// ```
-pub fn parse_command_attrs(attrs: &[Attribute]) -> Vec<CommandDef> {
-    attrs
-        .iter()
-        .filter(|attr| attr.path().is_ident("command"))
-        .filter_map(|attr| parse_single_command(attr).ok())
-        .collect()
+pub fn parse_command_attrs(attrs: &[Attribute]) -> syn::Result<Vec<CommandDef>> {
+    let mut commands = Vec::new();
+    let mut combined: Option<syn::Error> = None;
+
+    for attr in attrs.iter().filter(|a| a.path().is_ident("command")) {
+        match parse_single_command(attr) {
+            Ok(cmd) => commands.push(cmd),
+            Err(err) => match combined.as_mut() {
+                Some(existing) => existing.combine(err),
+                None => combined = Some(err)
+            }
+        }
+    }
+
+    if let Some(err) = combined {
+        return Err(err);
+    }
+    Ok(commands)
 }
 
 /// Parse a single `#[command(...)]` attribute.

--- a/crates/entity-derive-impl/src/entity/parse/command/tests.rs
+++ b/crates/entity-derive-impl/src/entity/parse/command/tests.rs
@@ -56,7 +56,7 @@ fn parse_simple_command() {
         #[command(Register)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].name.to_string(), "Register");
     assert_eq!(cmds[0].source, CommandSource::Create);
@@ -69,7 +69,7 @@ fn parse_command_with_fields() {
         #[command(UpdateEmail: email)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].name.to_string(), "UpdateEmail");
     if let CommandSource::Fields(ref fields) = cmds[0].source {
@@ -87,7 +87,7 @@ fn parse_command_with_multiple_fields() {
         #[command(UpdateProfile: name, avatar, bio)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     if let CommandSource::Fields(ref fields) = cmds[0].source {
         assert_eq!(fields.len(), 3);
@@ -105,7 +105,7 @@ fn parse_requires_id_command() {
         #[command(Deactivate, requires_id)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert!(cmds[0].requires_id);
     assert_eq!(cmds[0].source, CommandSource::None);
@@ -117,7 +117,7 @@ fn parse_custom_payload_command() {
         #[command(Transfer, payload = "TransferPayload")]
         struct Account {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert!(matches!(cmds[0].source, CommandSource::Custom(_)));
 }
@@ -128,7 +128,7 @@ fn parse_command_with_result() {
         #[command(Transfer, payload = "TransferPayload", result = "TransferResult")]
         struct Account {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert!(cmds[0].result_type.is_some());
 }
@@ -141,7 +141,7 @@ fn parse_multiple_commands() {
         #[command(Deactivate, requires_id)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 3);
     assert_eq!(cmds[0].name.to_string(), "Register");
     assert_eq!(cmds[1].name.to_string(), "UpdateEmail");
@@ -154,7 +154,7 @@ fn parse_kind_hint() {
         #[command(Delete, requires_id, kind = "delete")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].kind, CommandKindHint::Delete);
 }
@@ -177,7 +177,7 @@ fn parse_source_update() {
         #[command(Modify, source = "update")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].source, CommandSource::Update);
     assert!(cmds[0].requires_id);
@@ -190,7 +190,7 @@ fn parse_source_none() {
         #[command(Ping, source = "none")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].source, CommandSource::None);
 }
@@ -201,7 +201,7 @@ fn parse_source_create_explicit() {
         #[command(Register, source = "create")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].source, CommandSource::Create);
 }
@@ -212,7 +212,7 @@ fn parse_kind_create() {
         #[command(Register, kind = "create")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].kind, CommandKindHint::Create);
 }
@@ -223,7 +223,7 @@ fn parse_kind_update() {
         #[command(Modify, kind = "update")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].kind, CommandKindHint::Update);
 }
@@ -234,7 +234,7 @@ fn parse_kind_custom() {
         #[command(Process, kind = "custom")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].kind, CommandKindHint::Custom);
 }
@@ -245,39 +245,76 @@ fn parse_trailing_comma() {
         #[command(Register,)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].name.to_string(), "Register");
 }
 
+// Regression tests for #129 — invalid `#[command(...)]` attributes used to
+// be silently dropped via `filter_map(...ok())`, leaving the user with no
+// diagnostic and a mysteriously missing generated method. They now surface
+// as a `syn::Error` from `parse_command_attrs`, which the calling derive
+// emits as a `compile_error!` at the attribute span.
+
 #[test]
-fn parse_invalid_source_returns_empty() {
+fn parse_invalid_source_returns_error() {
     let input: syn::DeriveInput = syn::parse_quote! {
         #[command(Test, source = "invalid")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
-    assert!(cmds.is_empty());
+    let err =
+        parse_command_attrs(&input.attrs).expect_err("invalid source must report a parse error");
+    assert!(
+        err.to_string().contains("source must be"),
+        "diagnostic must name the offending option, got: {err}"
+    );
 }
 
 #[test]
-fn parse_invalid_kind_returns_empty() {
+fn parse_invalid_kind_returns_error() {
     let input: syn::DeriveInput = syn::parse_quote! {
         #[command(Test, kind = "invalid")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
-    assert!(cmds.is_empty());
+    let err =
+        parse_command_attrs(&input.attrs).expect_err("invalid kind must report a parse error");
+    assert!(
+        err.to_string().contains("kind must be"),
+        "diagnostic must name the offending option, got: {err}"
+    );
 }
 
 #[test]
-fn parse_unknown_option_returns_empty() {
+fn parse_unknown_option_returns_error() {
     let input: syn::DeriveInput = syn::parse_quote! {
         #[command(Test, unknown_option)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
-    assert!(cmds.is_empty());
+    let err =
+        parse_command_attrs(&input.attrs).expect_err("unknown option must report a parse error");
+    assert!(
+        err.to_string().contains("unknown command option"),
+        "diagnostic must mention the unknown option, got: {err}"
+    );
+}
+
+#[test]
+fn parse_combines_multiple_errors() {
+    // Both attributes are malformed in different ways. The accumulator
+    // should surface a single combined `syn::Error` so the user sees both
+    // in one compile pass.
+    let input: syn::DeriveInput = syn::parse_quote! {
+        #[command(First, source = "invalid")]
+        #[command(Second, kind = "invalid")]
+        struct User {}
+    };
+    let err = parse_command_attrs(&input.attrs)
+        .expect_err("two malformed attrs must produce one combined error");
+    let text = err.to_string();
+    assert!(
+        text.contains("source must be") || text.contains("kind must be"),
+        "combined error must reference at least one cause, got: {text}"
+    );
 }
 
 #[test]
@@ -287,7 +324,7 @@ fn ignores_non_command_attributes() {
         #[entity(table = "users")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert!(cmds.is_empty());
 }
 
@@ -297,7 +334,7 @@ fn parse_security_bearer() {
         #[command(AdminDelete, requires_id, security = "admin")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert_eq!(cmds[0].security(), Some("admin"));
     assert!(!cmds[0].is_public());
@@ -309,7 +346,7 @@ fn parse_security_none() {
         #[command(PublicList, security = "none")]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert!(cmds[0].is_public());
     assert!(cmds[0].has_security_override());
@@ -321,7 +358,7 @@ fn default_no_security_override() {
         #[command(Register)]
         struct User {}
     };
-    let cmds = parse_command_attrs(&input.attrs);
+    let cmds = parse_command_attrs(&input.attrs).expect("valid command parse");
     assert_eq!(cmds.len(), 1);
     assert!(!cmds[0].has_security_override());
     assert!(!cmds[0].is_public());

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -128,7 +128,7 @@ impl EntityDef {
 
         let has_many = parse_has_many_attrs(&input.attrs);
         let projections = parse_projection_attrs(&input.attrs);
-        let command_defs = parse_command_attrs(&input.attrs);
+        let command_defs = parse_command_attrs(&input.attrs).map_err(darling::Error::from)?;
         let api_config = parse_api_attr(&input.attrs);
         let indexes = parse_index_attrs(&input.attrs);
         let doc = extract_doc_comments(&input.attrs);

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.8.2"
+version = "0.8.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/tests/cases/fail/command_invalid_source.rs
+++ b/crates/entity-derive/tests/cases/fail/command_invalid_source.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+/// `source = "invalid"` is not one of the accepted values and must report
+/// a diagnostic instead of silently producing zero commands.
+#[derive(Entity)]
+#[entity(table = "items", commands)]
+#[command(Test, source = "invalid")]
+pub struct Item {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create)]
+    pub name: String,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/command_invalid_source.stderr
+++ b/crates/entity-derive/tests/cases/fail/command_invalid_source.stderr
@@ -1,0 +1,5 @@
+error: source must be "create", "update", or "none"
+  --> tests/cases/fail/command_invalid_source.rs:11:26
+   |
+11 | #[command(Test, source = "invalid")]
+   |                          ^^^^^^^^^

--- a/crates/entity-derive/tests/cases/fail/command_unknown_option.rs
+++ b/crates/entity-derive/tests/cases/fail/command_unknown_option.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+/// `#[command(..., bogus_option)]` must produce a compile error naming the
+/// offending option, instead of silently dropping the whole command (the
+/// pre-#129 behavior).
+#[derive(Entity)]
+#[entity(table = "items", commands)]
+#[command(Test, bogus_option)]
+pub struct Item {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create)]
+    pub name: String,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/command_unknown_option.stderr
+++ b/crates/entity-derive/tests/cases/fail/command_unknown_option.stderr
@@ -1,0 +1,5 @@
+error: unknown command option 'bogus_option', expected: requires_id, source, payload, result, kind, security
+  --> tests/cases/fail/command_unknown_option.rs:12:17
+   |
+12 | #[command(Test, bogus_option)]
+   |                 ^^^^^^^^^^^^


### PR DESCRIPTION
Closes #129

## Summary

\`parse_command_attrs\` swallowed every per-attribute parse error via \`filter_map(...ok())\`. A typo like \`#[command(Test, bogus_option)]\` produced no diagnostic and no generated method — the user only noticed at call site, far from the attribute. Same class of footgun fixed for \`#[map(...)]\` in #109; same pattern applied here.

## Changes

- Signature: \`parse_command_attrs(&[Attribute]) -> syn::Result<Vec<CommandDef>>\`. Multiple errors per struct are folded into one diagnostic via \`syn::Error::combine\` so the user sees every broken attribute in one compile pass.
- Caller (\`entity/parse/entity/constructor.rs\`) propagates via \`darling::Error::from(...)?\`, surfacing as a \`compile_error!\` at the attribute span.
- 24 successful-path tests updated to \`.expect("valid command parse")\` on the Result.
- 3 rewritten error tests (\`parse_invalid_source_returns_error\`, \`parse_invalid_kind_returns_error\`, \`parse_unknown_option_returns_error\`) assert the right diagnostic substring instead of the old "returns empty" behavior.
- New test \`parse_combines_multiple_errors\` for the accumulator.
- Two trybuild fail cases with \`.stderr\` fixtures: \`command_unknown_option\`, \`command_invalid_source\`.

## Version bump

| Crate | Old | New |
|---|---|---|
| entity-derive-impl | 0.6.1 | 0.6.2 |
| entity-derive | 0.8.2 | 0.8.3 |

\`entity-core\` is unchanged.

## Test plan

- [x] \`cargo test --all-features\` — 544 + 9 + 45 + 2 + 11 trybuild pass.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- [x] \`cargo +nightly fmt --all -- --check\` — clean.
- [ ] CI + Codecov green before merge.