### PR TITLE
fix(aggregate_root): emit Created event from save() for streams entities

### DIFF
--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.6.3"
+version = "0.6.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/sql/postgres/save.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/save.rs
@@ -75,6 +75,14 @@ impl Context<'_> {
 
         let span = instrument(&entity_name.to_string(), "save");
 
+        // `notify_created` returns an empty TokenStream when streams are off,
+        // so the same generator covers both streams-enabled and plain
+        // aggregate roots. When streams ARE on, the splice runs against the
+        // same transaction (`&mut *tx`) that wraps the INSERT, so Postgres
+        // only broadcasts the `Created` event on commit and discards it on
+        // rollback — atomic with the row write. See #133.
+        let notify = self.notify_created();
+
         quote! {
             #span
             async fn save(&self, new: #new_name) -> Result<#entity_name, #error_type> {
@@ -89,9 +97,86 @@ impl Context<'_> {
                     .fetch_one(&mut *tx).await?;
                 entity = #entity_name::from(row);
 
+                #notify
+
                 tx.commit().await?;
                 Ok(entity)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use syn::parse_quote;
+
+    use super::*;
+    use crate::entity::parse::EntityDef;
+
+    fn ctx_for(input: syn::DeriveInput) -> Context<'static> {
+        // Leak the parsed entity so the borrowed-against `Context` outlives
+        // the test scope. Acceptable in test code; saves shuffling lifetimes.
+        let entity: &'static EntityDef = Box::leak(Box::new(
+            EntityDef::from_derive_input(&input).expect("parse ok")
+        ));
+        Context::new(entity)
+    }
+
+    #[test]
+    fn save_emits_pg_notify_when_streams_enabled() {
+        let ctx = ctx_for(parse_quote! {
+            #[entity(table = "users", aggregate_root, streams)]
+            pub struct User {
+                #[id]
+                pub id: ::uuid::Uuid,
+                #[field(create, update, response)]
+                pub email: String
+            }
+        });
+        let tokens = ctx.save_method().to_string();
+        assert!(
+            tokens.contains("pg_notify"),
+            "streams + aggregate_root must splice pg_notify into save(), got: {tokens}"
+        );
+        // The notify must run on the transaction handle so it commits
+        // atomically with the INSERT, not after.
+        assert!(
+            tokens.contains("& mut * tx"),
+            "pg_notify must execute on `&mut *tx`, got: {tokens}"
+        );
+    }
+
+    #[test]
+    fn save_omits_pg_notify_when_streams_disabled() {
+        let ctx = ctx_for(parse_quote! {
+            #[entity(table = "users", aggregate_root)]
+            pub struct User {
+                #[id]
+                pub id: ::uuid::Uuid,
+                #[field(create, update, response)]
+                pub email: String
+            }
+        });
+        let tokens = ctx.save_method().to_string();
+        assert!(
+            !tokens.contains("pg_notify"),
+            "non-streams aggregate root must NOT emit pg_notify (perf regression guard), got: {tokens}"
+        );
+    }
+
+    #[test]
+    fn save_is_empty_for_non_aggregate_root() {
+        let ctx = ctx_for(parse_quote! {
+            #[entity(table = "users")]
+            pub struct User {
+                #[id]
+                pub id: ::uuid::Uuid
+            }
+        });
+        let tokens = ctx.save_method();
+        assert!(
+            tokens.is_empty(),
+            "save() must not be generated unless aggregate_root is on, got: {tokens}"
+        );
     }
 }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.8.4"
+version = "0.8.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION
Closes #133

## Summary

Missing companion to #125. \`save_method\` (aggregate-root INSERT) already used a transaction but never spliced \`pg_notify\` — so streams subscribers missed every new aggregate insert.

Now \`save()\` runs \`pg_notify\` against the same transaction handle (\`&mut *tx\`) used by the INSERT, before the commit. Postgres only broadcasts \`Created\` on commit, discards on rollback. When \`streams\` is off, \`notify_created()\` returns an empty TokenStream so non-streams aggregate roots keep their single round-trip.

## Tests (3 new)

| Test | Asserts |
|---|---|
| \`save_emits_pg_notify_when_streams_enabled\` | streams + aggregate_root produces body with \`pg_notify\` executed on \`&mut *tx\` |
| \`save_omits_pg_notify_when_streams_disabled\` | aggregate_root alone does NOT emit \`pg_notify\` (regression guard) |
| \`save_is_empty_for_non_aggregate_root\` | save_method returns empty without aggregate_root (control) |

## Version bump

| Crate | Old | New |
|---|---|---|
| entity-derive-impl | 0.6.3 | 0.6.4 |
| entity-derive | 0.8.4 | 0.8.5 |

\`entity-core\` is unchanged.

## Test plan

- [x] \`cargo test --all-features\` — 551 lib + 9 streams + 45 core + 2 integration + trybuild pass.
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` — clean.
- [x] \`cargo +nightly fmt --all -- --check\` — clean.
- [ ] CI + Codecov green before merge.