### PR TITLE
155

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 [workspace.package]
 version = "0.5.0"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/RAprogramm/entity-derive"
@@ -35,7 +35,7 @@ proc-macro2 = "1"
 darling = "0.23"
 convert_case = "0.11"
 async-trait = "0.1"
-sqlx = { version = "0.8", default-features = false }
+sqlx = { version = "0.9", default-features = false }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/STABILITY.md
+++ b/STABILITY.md
@@ -148,7 +148,7 @@ These features are planned but not yet implemented:
 
 ## Minimum Supported Rust Version (MSRV)
 
-- Current MSRV: **1.92.0**
+- Current MSRV: **1.96.0**
 - MSRV bumps are considered breaking changes pre-1.0
 - Post-1.0, MSRV bumps require at least a minor version bump
 

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -25,7 +25,7 @@ tracing = ["dep:tracing"]
 
 [dependencies]
 async-trait = "0.1"
-sqlx = { version = "0.8", optional = true, default-features = false, features = [
+sqlx = { version = "0.9", optional = true, default-features = false, features = [
   "postgres",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -70,7 +70,7 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
-sqlx = { version = "0.8", features = [
+sqlx = { version = "0.9", features = [
   "runtime-tokio",
   "postgres",
   "uuid",

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -161,7 +161,7 @@ impl Context<'_> {
                         #tx_open
                         let entity = #entity_name::from(dto);
                         let insertable = #insertable_name::from(&entity);
-                        sqlx::query(&format!("INSERT INTO {} ({}) VALUES ({}) RETURNING {}", #table, #columns_str, #placeholders_str, #returning_cols))
+                        sqlx::query(::sqlx::AssertSqlSafe(format!("INSERT INTO {} ({}) VALUES ({}) RETURNING {}", #table, #columns_str, #placeholders_str, #returning_cols)))
                             #(#bindings)*
                             .execute(#executor).await?;
                         #notify
@@ -207,7 +207,7 @@ impl Context<'_> {
             #span
             async fn find_by_id(&self, id: #id_type) -> Result<Option<#entity_name>, Self::Error> {
                 let row: Option<#row_name> = sqlx::query_as(
-                    &format!("SELECT {} FROM {} WHERE {} = {}{}", #columns_str, #table, stringify!(#id_name), #placeholder, #deleted_filter)
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} WHERE {} = {}{}", #columns_str, #table, stringify!(#id_name), #placeholder, #deleted_filter))
                 ).bind(&id).fetch_optional(self).await?;
                 Ok(row.map(#entity_name::from))
             }
@@ -270,7 +270,7 @@ impl Context<'_> {
                     let mut tx = self.begin().await?;
                     #fetch_old
                     let row: #row_name = sqlx::query_as(
-                        &format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder)
+                        ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder))
                     )
                         #(#bindings)*
                         .bind(&id)
@@ -292,7 +292,7 @@ impl Context<'_> {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
                         let row: #row_name = sqlx::query_as(
-                            &format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder)
+                            ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder))
                         )
                             #(#bindings)*
                             .bind(&id)
@@ -305,7 +305,7 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        sqlx::query(&format!("UPDATE {} SET {} WHERE {} = {}", #table, #set_clause, stringify!(#id_name), #where_placeholder))
+                        sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {}", #table, #set_clause, stringify!(#id_name), #where_placeholder)))
                             #(#bindings)*
                             .bind(&id)
                             .execute(self).await?;
@@ -318,7 +318,7 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        sqlx::query(&format!("UPDATE {} SET {} WHERE {} = {} RETURNING {}", #table, #set_clause, stringify!(#id_name), #where_placeholder, #returning_cols))
+                        sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING {}", #table, #set_clause, stringify!(#id_name), #where_placeholder, #returning_cols)))
                             #(#bindings)*
                             .bind(&id)
                             .execute(self).await?;
@@ -367,10 +367,10 @@ impl Context<'_> {
                 #span
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
                     #tx_open
-                    let result = sqlx::query(&format!(
+                    let result = sqlx::query(::sqlx::AssertSqlSafe(format!(
                         "UPDATE {} SET deleted_at = NOW() WHERE {} = {} AND deleted_at IS NULL",
                         #table, stringify!(#id_name), #placeholder
-                    )).bind(&id).execute(#executor).await?;
+                    ))).bind(&id).execute(#executor).await?;
                     let deleted = result.rows_affected() > 0;
                     if deleted {
                         #notify
@@ -386,7 +386,7 @@ impl Context<'_> {
                 #span
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
                     #tx_open
-                    let result = sqlx::query(&format!("DELETE FROM {} WHERE {} = {}", #table, stringify!(#id_name), #placeholder))
+                    let result = sqlx::query(::sqlx::AssertSqlSafe(format!("DELETE FROM {} WHERE {} = {}", #table, stringify!(#id_name), #placeholder)))
                         .bind(&id).execute(#executor).await?;
                     let deleted = result.rows_affected() > 0;
                     if deleted {
@@ -434,8 +434,8 @@ impl Context<'_> {
             #span
             async fn list(&self, limit: i64, offset: i64) -> Result<Vec<#entity_name>, Self::Error> {
                 let rows: Vec<#row_name> = sqlx::query_as(
-                    &format!("SELECT {} FROM {} {}ORDER BY {} DESC LIMIT {} OFFSET {}",
-                        #columns_str, #table, #where_clause, stringify!(#id_name), #limit_placeholder, #offset_placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} {}ORDER BY {} DESC LIMIT {} OFFSET {}",
+                        #columns_str, #table, #where_clause, stringify!(#id_name), #limit_placeholder, #offset_placeholder))
                 ).bind(limit).bind(offset).fetch_all(self).await?;
                 Ok(rows.into_iter().map(#entity_name::from).collect())
             }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/lookup.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/lookup.rs
@@ -33,14 +33,14 @@
 //! ```rust,ignore
 //! async fn find_by_email(&self, email: String) -> Result<Option<User>, Self::Error> {
 //!     let row: Option<UserRow> = sqlx::query_as(
-//!         &format!("SELECT * FROM users WHERE email = $1")
+//!         ::sqlx::AssertSqlSafe(format!("SELECT * FROM users WHERE email = $1"))
 //!     ).bind(&email).fetch_optional(self).await?;
 //!     Ok(row.map(User::from))
 //! }
 //!
 //! async fn exists_by_email(&self, email: String) -> Result<bool, Self::Error> {
 //!     let exists: bool = sqlx::query_scalar(
-//!         &format!("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)")
+//!         ::sqlx::AssertSqlSafe(format!("SELECT EXISTS(SELECT 1 FROM users WHERE email = $1)"))
 //!     ).bind(&email).fetch_one(self).await?;
 //!     Ok(exists)
 //! }
@@ -126,7 +126,7 @@ impl Context<'_> {
             #span
             async fn #method_name(&self, #field_name: #field_type) -> Result<Option<#entity_name>, Self::Error> {
                 let row: Option<#row_name> = sqlx::query_as(
-                    &format!("SELECT * FROM {} WHERE {} = {}", #table, stringify!(#field_name), #placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT * FROM {} WHERE {} = {}", #table, stringify!(#field_name), #placeholder))
                 ).bind(&#field_name).fetch_optional(self).await?;
                 Ok(row.map(#entity_name::from))
             }
@@ -160,7 +160,7 @@ impl Context<'_> {
             #span
             async fn #method_name(&self, #field_name: #field_type) -> Result<bool, Self::Error> {
                 let exists: bool = sqlx::query_scalar(
-                    &format!("SELECT EXISTS(SELECT 1 FROM {} WHERE {} = {})", #table, stringify!(#field_name), #placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT EXISTS(SELECT 1 FROM {} WHERE {} = {})", #table, stringify!(#field_name), #placeholder))
                 ).bind(&#field_name).fetch_one(self).await?;
                 Ok(exists)
             }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/projections.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/projections.rs
@@ -74,7 +74,7 @@ impl Context<'_> {
             #span
             async fn #method_name(&self, id: #id_type) -> Result<Option<#proj_type>, Self::Error> {
                 let row = sqlx::query_as::<_, #proj_type>(
-                    &format!("SELECT {} FROM {} WHERE {} = {}", #columns_str, #table, stringify!(#id_name), #placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} WHERE {} = {}", #columns_str, #table, stringify!(#id_name), #placeholder))
                 ).bind(&id).fetch_optional(self).await?;
                 Ok(row)
             }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/query.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/query.rs
@@ -112,7 +112,7 @@ impl Context<'_> {
                     #columns_str, #table, where_clause, stringify!(#id_name), limit_idx, offset_idx
                 );
 
-                let mut q = sqlx::query_as::<_, #row_name>(&sql);
+                let mut q = sqlx::query_as::<_, #row_name>(::sqlx::AssertSqlSafe(sql));
                 #bindings
                 q = q.bind(query.limit.unwrap_or(100)).bind(query.offset.unwrap_or(0));
 
@@ -179,7 +179,7 @@ impl Context<'_> {
                     #columns_str, #table, where_clause, stringify!(#id_name), limit_idx, offset_idx
                 );
 
-                let mut q = sqlx::query_as::<_, #row_name>(&sql);
+                let mut q = sqlx::query_as::<_, #row_name>(::sqlx::AssertSqlSafe(sql));
                 #bindings
                 q = q.bind(query.limit.unwrap_or(10000)).bind(query.offset.unwrap_or(0));
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres/relations.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/relations.rs
@@ -84,7 +84,7 @@ impl Context<'_> {
                 match entity {
                     Some(e) => {
                         let row: Option<#related_row> = sqlx::query_as(
-                            &format!("SELECT * FROM {} WHERE id = {}", #related_table, #placeholder)
+                            ::sqlx::AssertSqlSafe(format!("SELECT * FROM {} WHERE id = {}", #related_table, #placeholder))
                         ).bind(&e.#fk_name).fetch_optional(self).await?;
                         Ok(row.map(#related_entity::from))
                     }
@@ -116,7 +116,7 @@ impl Context<'_> {
         quote! {
             async fn #method_name(&self, #fk_field: #id_type) -> Result<Vec<#related>, Self::Error> {
                 let rows: Vec<#related_row> = sqlx::query_as(
-                    &format!("SELECT * FROM {} WHERE {}_id = {}", #related_table, #entity_snake, #placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT * FROM {} WHERE {}_id = {}", #related_table, #entity_snake, #placeholder))
                 ).bind(&#fk_field).fetch_all(self).await?;
                 Ok(rows.into_iter().map(#related::from).collect())
             }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/soft_delete.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/soft_delete.rs
@@ -72,10 +72,10 @@ impl Context<'_> {
 
         quote! {
             async fn hard_delete(&self, id: #id_type) -> Result<bool, Self::Error> {
-                let result = sqlx::query(&format!(
+                let result = sqlx::query(::sqlx::AssertSqlSafe(format!(
                     "DELETE FROM {} WHERE {} = {}",
                     #table, stringify!(#id_name), #placeholder
-                )).bind(&id).execute(self).await?;
+                ))).bind(&id).execute(self).await?;
                 Ok(result.rows_affected() > 0)
             }
         }
@@ -103,10 +103,10 @@ impl Context<'_> {
 
         quote! {
             async fn restore(&self, id: #id_type) -> Result<bool, Self::Error> {
-                let result = sqlx::query(&format!(
+                let result = sqlx::query(::sqlx::AssertSqlSafe(format!(
                     "UPDATE {} SET deleted_at = NULL WHERE {} = {} AND deleted_at IS NOT NULL",
                     #table, stringify!(#id_name), #placeholder
-                )).bind(&id).execute(self).await?;
+                ))).bind(&id).execute(self).await?;
                 Ok(result.rows_affected() > 0)
             }
         }
@@ -139,7 +139,7 @@ impl Context<'_> {
         quote! {
             async fn find_by_id_with_deleted(&self, id: #id_type) -> Result<Option<#entity_name>, Self::Error> {
                 let row: Option<#row_name> = sqlx::query_as(
-                    &format!("SELECT {} FROM {} WHERE {} = {}", #columns_str, #table, stringify!(#id_name), #placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} WHERE {} = {}", #columns_str, #table, stringify!(#id_name), #placeholder))
                 ).bind(&id).fetch_optional(self).await?;
                 Ok(row.map(#entity_name::from))
             }
@@ -175,8 +175,8 @@ impl Context<'_> {
         quote! {
             async fn list_with_deleted(&self, limit: i64, offset: i64) -> Result<Vec<#entity_name>, Self::Error> {
                 let rows: Vec<#row_name> = sqlx::query_as(
-                    &format!("SELECT {} FROM {} ORDER BY {} DESC LIMIT {} OFFSET {}",
-                        #columns_str, #table, stringify!(#id_name), #limit_placeholder, #offset_placeholder)
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} ORDER BY {} DESC LIMIT {} OFFSET {}",
+                        #columns_str, #table, stringify!(#id_name), #limit_placeholder, #offset_placeholder))
                 ).bind(limit).bind(offset).fetch_all(self).await?;
                 Ok(rows.into_iter().map(#entity_name::from).collect())
             }

--- a/crates/entity-derive-impl/src/entity/transaction.rs
+++ b/crates/entity-derive-impl/src/entity/transaction.rs
@@ -124,8 +124,8 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
                 dto: #update_dto
             ) -> Result<#entity_name, sqlx::Error> {
                 let row: #row_name = sqlx::query_as(
-                    &format!("UPDATE {} SET {} WHERE {} = {} RETURNING *",
-                        #table, #set_clause, stringify!(#id_name), #where_placeholder)
+                    ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING *",
+                        #table, #set_clause, stringify!(#id_name), #where_placeholder))
                 )
                     #(#update_bindings)*
                     .bind(&id)
@@ -137,18 +137,18 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
 
     let delete_sql = if soft_delete {
         quote! {
-            let result = sqlx::query(&format!(
+            let result = sqlx::query(::sqlx::AssertSqlSafe(format!(
                 "UPDATE {} SET deleted_at = NOW() WHERE {} = $1 AND deleted_at IS NULL",
                 #table, stringify!(#id_name)
-            )).bind(&id).execute(&mut **self.tx).await?;
+            ))).bind(&id).execute(&mut **self.tx).await?;
             Ok(result.rows_affected() > 0)
         }
     } else {
         quote! {
-            let result = sqlx::query(&format!(
+            let result = sqlx::query(::sqlx::AssertSqlSafe(format!(
                 "DELETE FROM {} WHERE {} = $1",
                 #table, stringify!(#id_name)
-            )).bind(&id).execute(&mut **self.tx).await?;
+            ))).bind(&id).execute(&mut **self.tx).await?;
             Ok(result.rows_affected() > 0)
         }
     };
@@ -188,8 +188,8 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
                 id: #id_type
             ) -> Result<Option<#entity_name>, sqlx::Error> {
                 let row: Option<#row_name> = sqlx::query_as(
-                    &format!("SELECT {} FROM {} WHERE {} = $1{}",
-                        #columns_str, #table, stringify!(#id_name), #deleted_filter)
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} WHERE {} = $1{}",
+                        #columns_str, #table, stringify!(#id_name), #deleted_filter))
                 ).bind(&id).fetch_optional(&mut **self.tx).await?;
                 Ok(row.map(#entity_name::from))
             }
@@ -214,8 +214,8 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
             ) -> Result<Vec<#entity_name>, sqlx::Error> {
                 let where_clause = if #soft_delete { "WHERE deleted_at IS NULL " } else { "" };
                 let rows: Vec<#row_name> = sqlx::query_as(
-                    &format!("SELECT {} FROM {} {}ORDER BY {} DESC LIMIT $1 OFFSET $2",
-                        #columns_str, #table, where_clause, stringify!(#id_name))
+                    ::sqlx::AssertSqlSafe(format!("SELECT {} FROM {} {}ORDER BY {} DESC LIMIT $1 OFFSET $2",
+                        #columns_str, #table, where_clause, stringify!(#id_name)))
                 ).bind(limit).bind(offset).fetch_all(&mut **self.tx).await?;
                 Ok(rows.into_iter().map(#entity_name::from).collect())
             }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -27,7 +27,7 @@ default = [
   "transactions",
   "aggregate_root",
   "migrations",
-  "projections"
+  "projections",
 ]
 
 # Database dialects
@@ -83,7 +83,7 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
-sqlx = { version = "0.8", features = [
+sqlx = { version = "0.9", features = [
   "runtime-tokio",
   "postgres",
   "uuid",

--- a/deny.toml
+++ b/deny.toml
@@ -17,10 +17,10 @@ all-features = true
 version = 2
 db-path = "~/.cargo/advisory-db"
 ignore = [
-    # rsa timing side-channel (Marvin Attack) - no fix available
-    # This crate only supports PostgreSQL. MySQL is NOT used and NOT recommended.
-    # The vulnerable rsa crate is pulled transitively by sqlx-mysql (dev-dependency only).
-    "RUSTSEC-2023-0071",
+    # proc-macro-error2 is unmaintained, no safe upgrade available.
+    # Pulled transitively by validator_derive -> validator (dev-dependency only).
+    # https://github.com/GnomedDev/proc-macro-error-2/issues/17
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -16,17 +16,25 @@ validate = []
 tracing = []
 
 [dependencies]
-entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
+entity-derive = { path = "../../crates/entity-derive", features = [
+  "postgres",
+  "api",
+] }
 masterror = { version = "0.27", features = ["axum", "openapi"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = [
+  "runtime-tokio",
+  "postgres",
+  "uuid",
+  "chrono",
+] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
-tower-http = { version = "0.6", features = ["trace"] }
+tower-http = { version = "0.7", features = ["trace"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }

--- a/examples/commands/Cargo.toml
+++ b/examples/commands/Cargo.toml
@@ -16,11 +16,19 @@ validate = []
 tracing = []
 
 [dependencies]
-entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
+entity-derive = { path = "../../crates/entity-derive", features = [
+  "postgres",
+  "api",
+] }
 entity-core = { path = "../../crates/entity-core", features = ["postgres"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = [
+  "runtime-tokio",
+  "postgres",
+  "uuid",
+  "chrono",
+] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/events/Cargo.toml
+++ b/examples/events/Cargo.toml
@@ -16,11 +16,19 @@ validate = []
 tracing = []
 
 [dependencies]
-entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
+entity-derive = { path = "../../crates/entity-derive", features = [
+  "postgres",
+  "api",
+] }
 entity-core = { path = "../../crates/entity-core", features = ["postgres"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full", "sync"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = [
+  "runtime-tokio",
+  "postgres",
+  "uuid",
+  "chrono",
+] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/filtering/Cargo.toml
+++ b/examples/filtering/Cargo.toml
@@ -19,7 +19,7 @@ tracing = []
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/full-app/Cargo.toml
+++ b/examples/full-app/Cargo.toml
@@ -18,20 +18,32 @@ validate = []
 tracing = []
 
 [dependencies]
-entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api", "streams"] }
-entity-core = { path = "../../crates/entity-core", features = ["postgres", "streams"] }
+entity-derive = { path = "../../crates/entity-derive", features = [
+  "postgres",
+  "api",
+  "streams",
+] }
+entity-core = { path = "../../crates/entity-core", features = [
+  "postgres",
+  "streams",
+] }
 masterror = { version = "0.27", features = ["axum", "openapi"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full", "sync"] }
 tokio-stream = "0.1"
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = [
+  "runtime-tokio",
+  "postgres",
+  "uuid",
+  "chrono",
+] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 async-trait = "0.1"
 futures = "0.3"
-tower-http = { version = "0.6", features = ["trace", "cors"] }
+tower-http = { version = "0.7", features = ["trace", "cors"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }

--- a/examples/hooks/Cargo.toml
+++ b/examples/hooks/Cargo.toml
@@ -16,10 +16,18 @@ validate = []
 tracing = []
 
 [dependencies]
-entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
+entity-derive = { path = "../../crates/entity-derive", features = [
+  "postgres",
+  "api",
+] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = [
+  "runtime-tokio",
+  "postgres",
+  "uuid",
+  "chrono",
+] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/relations/Cargo.toml
+++ b/examples/relations/Cargo.toml
@@ -19,7 +19,7 @@ tracing = []
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/soft-delete/Cargo.toml
+++ b/examples/soft-delete/Cargo.toml
@@ -19,7 +19,7 @@ tracing = []
 entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/streams/Cargo.toml
+++ b/examples/streams/Cargo.toml
@@ -16,12 +16,24 @@ validate = []
 tracing = []
 
 [dependencies]
-entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "api", "streams"] }
-entity-core = { path = "../../crates/entity-core", features = ["postgres", "streams"] }
+entity-derive = { path = "../../crates/entity-derive", features = [
+  "postgres",
+  "api",
+  "streams",
+] }
+entity-core = { path = "../../crates/entity-core", features = [
+  "postgres",
+  "streams",
+] }
 axum = "0.8"
 tokio = { version = "1", features = ["full", "sync"] }
 tokio-stream = "0.1"
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = [
+  "runtime-tokio",
+  "postgres",
+  "uuid",
+  "chrono",
+] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }

--- a/examples/transactions/Cargo.toml
+++ b/examples/transactions/Cargo.toml
@@ -24,7 +24,7 @@ entity-derive = { path = "../../crates/entity-derive", features = ["postgres", "
 entity-core = { path = "../../crates/entity-core", features = ["postgres"] }
 axum = "0.8"
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.8", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
 uuid = { version = "1", features = ["v4", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Closes #155.

- Bumps sqlx to 0.9 across workspace and all examples (single lockfile version), rust-version 1.96.
- sqlx 0.9 requires `impl SqlSafeStr` for query strings: all generated dynamic-SQL call sites (`crud`, `query`, `lookup`, `relations`, `projections`, `soft_delete`, `transaction`) now wrap their `format!`-built strings in `sqlx::AssertSqlSafe`. These strings are composed exclusively from macro-controlled table/column identifiers, never runtime user input.
- `'static` `concat!` query sites left unwrapped.

Verified: `cargo test --workspace --all-features` green (567 unit + trybuild), clippy clean, all 10 examples build.