### PR TITLE
143

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ license = "MIT"
 repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
-entity-core = { path = "crates/entity-core", version = "0.6" }
-entity-derive = { path = "crates/entity-derive", version = "0.8" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.6" }
+entity-core = { path = "crates/entity-core", version = "0.7" }
+entity-derive = { path = "crates/entity-derive", version = "0.10" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.8" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.9", features = ["postgres", "api"] }
+entity-derive = { version = "0.10", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -105,7 +105,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.9", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.10", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -114,7 +114,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.9", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.10", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -211,6 +211,41 @@ tracing-subscriber = "0.3"
 #[projection(Name: fields)]    // Partial view
 ```
 
+### Postgres Enums
+
+Derive `ValueObject` on a status-style enum and reference it from entities
+with `#[column(pg_enum = "...")]`:
+
+```rust,ignore
+#[derive(ValueObject, Debug, Clone, Serialize, Deserialize)]
+#[value_object(pg_type = "order_status", sqlx)]
+pub enum OrderStatus { Pending, Shipped, Delivered }
+
+#[derive(Entity)]
+#[entity(table = "orders", migrations)]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+    #[field(create, update, response)]
+    #[column(pg_enum = "order_status")]
+    pub status: OrderStatus,
+}
+
+for ddl in Order::MIGRATION_TYPES {
+    sqlx::query(ddl).execute(&pool).await?;
+}
+sqlx::query(Order::MIGRATION_UP).execute(&pool).await?;
+```
+
+- `ValueObject` generates `PG_TYPE` and idempotent `PG_CREATE_TYPE` constants;
+  the opt-in `sqlx` flag additionally emits `sqlx::Type` / `Encode` / `Decode`
+  impls so the enum binds and decodes without hand-written glue (omit it if
+  you already derive `sqlx::Type` yourself).
+- `#[column(pg_enum = "...")]` sets the DDL column type and registers the
+  enum's DDL in `{Entity}::MIGRATION_TYPES` — run those before `MIGRATION_UP`.
+- The declared name is checked against the enum's `pg_type` at compile time;
+  a typo fails the build.
+
 ### Upsert
 
 Declare a conflict target with a uniqueness guarantee (`#[id]`,
@@ -273,7 +308,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.9", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.10", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -408,7 +408,6 @@ mod tests {
     fn const_str_eq_in_const_context() {
         const OK: bool = const_str_eq("user_role", "user_role");
         const MISMATCH: bool = const_str_eq("user_role", "user_rank");
-        assert!(OK);
-        assert!(!MISMATCH);
+        assert_eq!((OK, MISMATCH), (true, false));
     }
 }

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -40,6 +40,28 @@ pub mod transaction;
 /// Re-export `async_trait` for generated code.
 pub use async_trait::async_trait;
 
+/// Compare two strings in const context.
+///
+/// Used by generated code to verify at compile time that
+/// `#[column(pg_enum = "...")]` matches the `ValueObject`'s
+/// `#[value_object(pg_type = "...")]` declaration.
+#[must_use]
+pub const fn const_str_eq(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
 /// Base repository trait.
 ///
 /// All generated `{Entity}Repository` traits include these associated types

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -385,4 +385,30 @@ mod tests {
         assert!(CommandKind::Delete.is_mutation());
         assert!(!CommandKind::Custom.is_mutation());
     }
+
+    #[test]
+    fn const_str_eq_equal_strings() {
+        assert!(const_str_eq("order_status", "order_status"));
+        assert!(const_str_eq("", ""));
+    }
+
+    #[test]
+    fn const_str_eq_different_lengths() {
+        assert!(!const_str_eq("order", "order_status"));
+        assert!(!const_str_eq("order_status", ""));
+    }
+
+    #[test]
+    fn const_str_eq_same_length_different_content() {
+        assert!(!const_str_eq("order_status", "order_states"));
+        assert!(!const_str_eq("abc", "abd"));
+    }
+
+    #[test]
+    fn const_str_eq_in_const_context() {
+        const OK: bool = const_str_eq("user_role", "user_role");
+        const MISMATCH: bool = const_str_eq("user_role", "user_rank");
+        assert!(OK);
+        assert!(!MISMATCH);
+    }
 }

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/migrations/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres.rs
@@ -9,8 +9,22 @@ mod ddl;
 
 use proc_macro2::TokenStream;
 use quote::quote;
+use syn::Type;
 
 use crate::{entity::parse::EntityDef, utils::marker};
+
+/// Strip `Option<...>` and `Vec<...>` wrappers to reach the enum type.
+fn base_type(ty: &Type) -> &Type {
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && (segment.ident == "Option" || segment.ident == "Vec")
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return base_type(inner);
+    }
+    ty
+}
 
 /// Generate migration constants for `PostgreSQL`.
 ///
@@ -28,6 +42,34 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     let up_sql = ddl::generate_up(entity);
     let down_sql = ddl::generate_down(entity);
+
+    let enum_fields: Vec<(&Type, String)> = entity
+        .all_fields()
+        .iter()
+        .filter_map(|f| {
+            f.column
+                .pg_enum
+                .as_ref()
+                .map(|pg_enum| (base_type(f.ty()), pg_enum.clone()))
+        })
+        .collect();
+
+    let create_type_refs: Vec<TokenStream> = enum_fields
+        .iter()
+        .map(|(ty, _)| quote! { <#ty>::PG_CREATE_TYPE })
+        .collect();
+
+    let name_assertions: Vec<TokenStream> = enum_fields
+        .iter()
+        .map(|(ty, declared)| {
+            quote! {
+                assert!(
+                    ::entity_core::const_str_eq(<#ty>::PG_TYPE, #declared),
+                    "#[column(pg_enum = ...)] does not match the ValueObject's pg_type"
+                );
+            }
+        })
+        .collect();
 
     let marker = marker::generated();
 
@@ -47,6 +89,102 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             ///
             /// Uses CASCADE to drop dependent objects.
             #vis const MIGRATION_DOWN: &'static str = #down_sql;
+
+            /// Idempotent DDL for Postgres enum types this table depends on.
+            ///
+            /// One statement per `#[column(pg_enum = "...")]` field, in
+            /// declaration order. Execute before [`Self::MIGRATION_UP`]:
+            ///
+            /// ```rust,ignore
+            /// for ddl in User::MIGRATION_TYPES {
+            ///     sqlx::query(ddl).execute(&pool).await?;
+            /// }
+            /// sqlx::query(User::MIGRATION_UP).execute(&pool).await?;
+            /// ```
+            #vis const MIGRATION_TYPES: &'static [&'static str] = &[#(#create_type_refs),*];
         }
+
+        const _: () = {
+            #(#name_assertions)*
+        };
+    }
+}
+
+#[cfg(test)]
+mod pg_enum_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    fn status_entity() -> EntityDef {
+        parse_entity(quote! {
+            #[entity(table = "orders", migrations)]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                #[column(pg_enum = "order_status")]
+                pub status: OrderStatus,
+            }
+        })
+    }
+
+    #[test]
+    fn migration_types_lists_enum_ddl() {
+        let code = generate(&status_entity()).to_string();
+        assert!(code.contains("MIGRATION_TYPES"));
+        assert!(code.contains("OrderStatus > :: PG_CREATE_TYPE"));
+    }
+
+    #[test]
+    fn name_assertion_emitted() {
+        let code = generate(&status_entity()).to_string();
+        assert!(code.contains("const_str_eq"));
+        assert!(code.contains("\"order_status\""));
+    }
+
+    #[test]
+    fn ddl_uses_enum_type_name() {
+        let code = generate(&status_entity()).to_string();
+        assert!(code.contains("status order_status NOT NULL"));
+    }
+
+    #[test]
+    fn no_enums_produces_empty_list() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users", migrations)]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub name: String,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(code.contains("MIGRATION_TYPES"));
+        assert!(!code.contains("PG_CREATE_TYPE"));
+    }
+
+    #[test]
+    fn option_wrapper_unwrapped_for_const_ref() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "orders", migrations)]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                #[column(pg_enum = "order_status")]
+                pub status: Option<OrderStatus>,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(code.contains("OrderStatus > :: PG_CREATE_TYPE"));
+        assert!(!code.contains("Option < OrderStatus > :: PG_CREATE_TYPE"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/migrations/types/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/types/postgres.rs
@@ -55,6 +55,15 @@ impl TypeMapper for PostgresTypeMapper {
             };
         }
 
+        // Postgres enum type declared via #[column(pg_enum = "...")]
+        if let Some(ref pg_enum) = column.pg_enum {
+            return SqlType {
+                name:      pg_enum.clone(),
+                nullable:  is_option(ty) || column.nullable,
+                array_dim: 0
+            };
+        }
+
         // Handle Option<T>
         if let Some(inner) = extract_option_inner(ty) {
             let mut result = self.map_type(inner, column);

--- a/crates/entity-derive-impl/src/entity/parse/field/column.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/column.rs
@@ -165,6 +165,14 @@ pub struct ColumnConfig {
     /// Bypasses automatic type mapping.
     pub sql_type: Option<String>,
 
+    /// Postgres enum type name for `ValueObject` fields.
+    ///
+    /// Sets the DDL column type and registers the field type's
+    /// `PG_CREATE_TYPE` DDL in `{Entity}::MIGRATION_TYPES`. The name is
+    /// checked against the field type's `PG_TYPE` constant at compile
+    /// time.
+    pub pg_enum: Option<String>,
+
     /// Explicitly allow NULL even for non-Option types.
     pub nullable: bool,
 
@@ -218,6 +226,10 @@ impl ColumnConfig {
                     let _: syn::Token![=] = meta.input.parse()?;
                     let value: syn::LitStr = meta.input.parse()?;
                     config.sql_type = Some(value.value());
+                } else if meta.path.is_ident("pg_enum") {
+                    let _: syn::Token![=] = meta.input.parse()?;
+                    let value: syn::LitStr = meta.input.parse()?;
+                    config.pg_enum = Some(value.value());
                 } else if meta.path.is_ident("nullable") {
                     config.nullable = true;
                 } else if meta.path.is_ident("name") {

--- a/crates/entity-derive-impl/src/value_object.rs
+++ b/crates/entity-derive-impl/src/value_object.rs
@@ -98,8 +98,8 @@ fn generate(input: &DeriveInput) -> syn::Result<TokenStream2> {
         }
     };
 
-    // Validate pg_type attribute exists (but we don't use it in trait impls)
-    extract_pg_type(&input.attrs)?;
+    let pg_type = extract_pg_type(&input.attrs)?;
+    let generate_sqlx = extract_sqlx_flag(&input.attrs);
 
     // Build lowercase variant names using convert_case
     let variant_names: Vec<String> = variants
@@ -141,7 +141,63 @@ fn generate(input: &DeriveInput) -> syn::Result<TokenStream2> {
         })
         .collect();
 
+    let create_type_sql = format!(
+        "DO $$ BEGIN CREATE TYPE {} AS ENUM ({}); EXCEPTION WHEN duplicate_object THEN NULL; END $$;",
+        pg_type,
+        variant_names
+            .iter()
+            .map(|v| format!("'{v}'"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    );
+
+    let sqlx_impls = if generate_sqlx {
+        quote! {
+            #[cfg(feature = "postgres")]
+            impl ::sqlx::Type<::sqlx::Postgres> for #name {
+                fn type_info() -> ::sqlx::postgres::PgTypeInfo {
+                    ::sqlx::postgres::PgTypeInfo::with_name(#pg_type)
+                }
+            }
+
+            #[cfg(feature = "postgres")]
+            impl<'q> ::sqlx::Encode<'q, ::sqlx::Postgres> for #name {
+                fn encode_by_ref(
+                    &self,
+                    buf: &mut ::sqlx::postgres::PgArgumentBuffer
+                ) -> Result<::sqlx::encode::IsNull, ::sqlx::error::BoxDynError> {
+                    <&str as ::sqlx::Encode<'q, ::sqlx::Postgres>>::encode_by_ref(&self.as_ref(), buf)
+                }
+            }
+
+            #[cfg(feature = "postgres")]
+            impl<'r> ::sqlx::Decode<'r, ::sqlx::Postgres> for #name {
+                fn decode(
+                    value: ::sqlx::postgres::PgValueRef<'r>
+                ) -> Result<Self, ::sqlx::error::BoxDynError> {
+                    let s = <&str as ::sqlx::Decode<'r, ::sqlx::Postgres>>::decode(value)?;
+                    s.parse().map_err(Into::into)
+                }
+            }
+        }
+    } else {
+        TokenStream2::new()
+    };
+
     Ok(quote! {
+        impl #name {
+            /// Postgres enum type name declared via `#[value_object(pg_type = "...")]`.
+            pub const PG_TYPE: &'static str = #pg_type;
+
+            /// Idempotent DDL creating the Postgres enum type.
+            ///
+            /// Safe to run repeatedly: an existing type is left untouched.
+            /// Execute before `MIGRATION_UP` of entities using this enum.
+            pub const PG_CREATE_TYPE: &'static str = #create_type_sql;
+        }
+
+        #sqlx_impls
+
         impl std::fmt::Display for #name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 match self {
@@ -216,6 +272,34 @@ fn extract_pg_type(attrs: &[syn::Attribute]) -> syn::Result<String> {
             "missing #[value_object(pg_type = \"...\")] attribute"
         )
     })
+}
+
+/// Whether `#[value_object(..., sqlx)]` requests generated sqlx impls.
+///
+/// When set, the derive emits `sqlx::Type`, `Encode` and `Decode`
+/// implementations for Postgres (gated behind the user's `postgres`
+/// feature). Off by default so enums that already derive `sqlx::Type`
+/// keep compiling.
+fn extract_sqlx_flag(attrs: &[syn::Attribute]) -> bool {
+    let mut flag = false;
+
+    for attr in attrs {
+        if attr.path().is_ident("value_object")
+            && let syn::Meta::List(meta_list) = &attr.meta
+        {
+            let _ = meta_list.parse_nested_meta(|meta| {
+                if meta.path.is_ident("pg_type") {
+                    let val_stream = meta.value()?;
+                    let _: LitStr = val_stream.parse()?;
+                } else if meta.path.is_ident("sqlx") {
+                    flag = true;
+                }
+                Ok(())
+            });
+        }
+    }
+
+    flag
 }
 
 #[cfg(test)]
@@ -528,5 +612,67 @@ mod tests {
         assert!(output.contains("FromStrforStatus"));
         assert!(output.contains("AsRef<str>forStatus"));
         assert!(output.contains("TryFrom<&str>forStatus"));
+    }
+}
+
+#[cfg(test)]
+mod pg_type_tests {
+    use super::*;
+
+    #[test]
+    fn generates_pg_type_const() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "order_status")]
+            enum OrderStatus { Pending, Shipped }
+        };
+        let code = generate(&input).unwrap().to_string();
+        assert!(code.contains("PG_TYPE"));
+        assert!(code.contains("\"order_status\""));
+    }
+
+    #[test]
+    fn generates_idempotent_create_type() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "order_status")]
+            enum OrderStatus { Pending, Shipped }
+        };
+        let code = generate(&input).unwrap().to_string();
+        assert!(code.contains(
+            "DO $$ BEGIN CREATE TYPE order_status AS ENUM ('pending', 'shipped'); \
+             EXCEPTION WHEN duplicate_object THEN NULL; END $$;"
+        ));
+    }
+
+    #[test]
+    fn sqlx_impls_absent_by_default() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "order_status")]
+            enum OrderStatus { Pending }
+        };
+        let code = generate(&input).unwrap().to_string();
+        assert!(!code.contains("Encode"));
+        assert!(!code.contains("Decode"));
+    }
+
+    #[test]
+    fn sqlx_flag_generates_impls() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "order_status", sqlx)]
+            enum OrderStatus { Pending }
+        };
+        let code = generate(&input).unwrap().to_string();
+        assert!(code.contains("Encode"));
+        assert!(code.contains("Decode"));
+        assert!(code.contains("type_info"));
+    }
+
+    #[test]
+    fn multi_word_variants_snake_cased() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "kind")]
+            enum Kind { InReview, DoneDeal }
+        };
+        let code = generate(&input).unwrap().to_string();
+        assert!(code.contains("'in_review', 'done_deal'"));
     }
 }

--- a/crates/entity-derive-impl/src/value_object.rs
+++ b/crates/entity-derive-impl/src/value_object.rs
@@ -676,3 +676,45 @@ mod pg_type_tests {
         assert!(code.contains("'in_review', 'done_deal'"));
     }
 }
+
+#[cfg(test)]
+mod sqlx_flag_tests {
+    use super::*;
+
+    #[test]
+    fn flag_absent_returns_false() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "kind")]
+            enum Kind { A }
+        };
+        assert!(!extract_sqlx_flag(&input.attrs));
+    }
+
+    #[test]
+    fn flag_present_returns_true() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(pg_type = "kind", sqlx)]
+            enum Kind { A }
+        };
+        assert!(extract_sqlx_flag(&input.attrs));
+    }
+
+    #[test]
+    fn unrelated_attribute_ignored() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[derive(Debug)]
+            #[allow(dead_code)]
+            enum Kind { A }
+        };
+        assert!(!extract_sqlx_flag(&input.attrs));
+    }
+
+    #[test]
+    fn flag_before_pg_type_returns_true() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[value_object(sqlx, pg_type = "kind")]
+            enum Kind { A }
+        };
+        assert!(extract_sqlx_flag(&input.attrs));
+    }
+}

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -73,8 +73,8 @@ projections = ["entity-derive-impl/projections"]
 tracing = ["entity-core/tracing"]
 
 [dependencies]
-entity-core = { path = "../entity-core", version = "0.6" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.7", default-features = false }
+entity-core = { path = "../entity-core", version = "0.7" }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.8", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/fail/pg_enum_name_mismatch.rs
+++ b/crates/entity-derive/tests/cases/fail/pg_enum_name_mismatch.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::{Entity, ValueObject};
+use uuid::Uuid;
+
+#[derive(ValueObject, Debug, Clone, utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+#[value_object(pg_type = "order_status", sqlx)]
+pub enum OrderStatus {
+    Pending,
+    Shipped,
+}
+
+#[derive(Entity)]
+#[entity(table = "orders", migrations)]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[column(pg_enum = "order_state")]
+    pub status: OrderStatus,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/pg_enum_name_mismatch.stderr
+++ b/crates/entity-derive/tests/cases/fail/pg_enum_name_mismatch.stderr
@@ -1,0 +1,5 @@
+error[E0080]: evaluation panicked: #[column(pg_enum = ...)] does not match the ValueObject's pg_type
+  --> tests/cases/fail/pg_enum_name_mismatch.rs:14:10
+   |
+14 | #[derive(Entity)]
+   |          ^^^^^^ evaluation of `_` failed here

--- a/crates/entity-derive/tests/cases/pass/pg_enum_entity.rs
+++ b/crates/entity-derive/tests/cases/pass/pg_enum_entity.rs
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::{Entity, ValueObject};
+use uuid::Uuid;
+
+#[derive(ValueObject, Debug, Clone, PartialEq, Eq, utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+#[value_object(pg_type = "order_status", sqlx)]
+pub enum OrderStatus {
+    Pending,
+    Shipped,
+    Delivered,
+}
+
+#[derive(Entity)]
+#[entity(table = "orders", migrations)]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[column(pg_enum = "order_status")]
+    pub status: OrderStatus,
+
+    #[field(create, update, response)]
+    pub note: Option<String>,
+}
+
+fn main() {
+    assert_eq!(OrderStatus::PG_TYPE, "order_status");
+    assert!(OrderStatus::PG_CREATE_TYPE.contains("CREATE TYPE order_status AS ENUM"));
+    assert!(OrderStatus::PG_CREATE_TYPE.contains("'pending', 'shipped', 'delivered'"));
+
+    assert_eq!(Order::MIGRATION_TYPES.len(), 1);
+    assert_eq!(Order::MIGRATION_TYPES[0], OrderStatus::PG_CREATE_TYPE);
+    assert!(Order::MIGRATION_UP.contains("status order_status NOT NULL"));
+}


### PR DESCRIPTION
Closes #143.

Wires `ValueObject` Postgres enums into Entity DDL generation.

## ValueObject

- Generates `PG_TYPE` (declared type name) and `PG_CREATE_TYPE` (idempotent `DO $$ ... CREATE TYPE ... EXCEPTION WHEN duplicate_object` DDL) constants.
- New opt-in `sqlx` flag (`#[value_object(pg_type = "...", sqlx)]`) emits `sqlx::Type` / `Encode` / `Decode` impls (gated behind the consumer's `postgres` feature). Off by default — enums that already derive `sqlx::Type` keep compiling unchanged.

## Entity

- New `#[column(pg_enum = "type_name")]` field option: sets the DDL column type (previously enum fields silently fell back to TEXT) and registers the field type's `PG_CREATE_TYPE` in a new `{Entity}::MIGRATION_TYPES` constant to run before `MIGRATION_UP`.
- The declared name is verified against the enum's `PG_TYPE` at compile time via a const assertion (`entity_core::const_str_eq`) — a typo fails the build with a clear message.

## Testing

- 10 new unit tests (ValueObject consts/flag, DDL mapping, MIGRATION_TYPES, Option unwrapping) — 603 total green
- trybuild: pass case (full enum round-trip incl. runtime const assertions), fail case pinned to the single E0080 name-mismatch error
- Verified under default and `--all-features` builds; examples compile

## Docs & versions

- README: new "Postgres Enums" section, version pins 0.10
- entity-core 0.6.0 → 0.7.0 (new `const_str_eq`), entity-derive-impl 0.7.0 → 0.8.0, entity-derive 0.9.0 → 0.10.0
- Wiki (Attributes, 5 languages) will be updated right after merge