### PR TITLE
145

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.7" }
-entity-derive = { path = "crates/entity-derive", version = "0.11" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.9" }
+entity-derive = { path = "crates/entity-derive", version = "0.12" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.10" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.11", features = ["postgres", "api"] }
+entity-derive = { version = "0.12", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -105,7 +105,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.11", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.12", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -114,7 +114,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.11", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.12", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -131,6 +131,7 @@ tracing-subscriber = "0.3"
 | **`OpenAPI` Docs** | Auto-generated Swagger/OpenAPI documentation |
 | **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]` |
 | **Relations** | `#[belongs_to]` and `#[has_many]` |
+| **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
 | **Aggregate Roots** | `#[entity(aggregate_root)]` with `New{T}` DTOs and transactional `save` |
 | **Transactions** | Multi-entity atomic operations |
@@ -201,6 +202,7 @@ tracing-subscriber = "0.3"
 ```rust,ignore
 #[id]                          // Primary key (auto-generated UUID)
 #[auto]                        // Auto-generated (timestamps)
+#[owner]                       // Ownership column: adds *_scoped methods
 #[field(create)]               // Include in CreateRequest
 #[field(update)]               // Include in UpdateRequest
 #[field(response)]             // Include in Response
@@ -212,6 +214,33 @@ tracing-subscriber = "0.3"
 #[has_many(Entity)]            // One-to-many relation
 #[projection(Name: fields)]    // Partial view
 ```
+
+### Ownership Scoping
+
+Mark the column carrying the owning principal's id with `#[owner]` and the
+repository gains row-level scoped methods — "only this user's rows" without
+hand-written predicates:
+
+```rust,ignore
+#[derive(Entity)]
+#[entity(table = "orders")]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+    #[owner]
+    pub user_id: Uuid,
+    #[field(create, update, response)]
+    pub note: String,
+}
+
+let mine: Vec<Order> = pool.list_by_owner(user_id, 20, 0).await?;
+let order = pool.find_by_id_scoped(id, user_id).await?;          // None if not theirs
+let updated = pool.update_scoped(id, user_id, patch).await?;     // None if not theirs
+let removed = pool.delete_scoped(id, user_id).await?;            // false if not theirs
+```
+
+Scoped reads and writes never reveal whether a row exists for another
+owner, and all of them respect `soft_delete`.
 
 ### Handler Guards
 
@@ -339,7 +368,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.11", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.12", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
@@ -114,6 +114,15 @@ impl EntityDef {
     ///
     /// These database-layer structs include ALL fields from the
     /// entity, regardless of DTO inclusion settings.
+    /// Get the `#[owner]` field, if any.
+    ///
+    /// Marks the column carrying the owning principal's id and enables
+    /// generated row-level scoped repository methods.
+    #[must_use]
+    pub fn owner_field(&self) -> Option<&FieldDef> {
+        self.fields.iter().find(|f| f.storage.is_owner)
+    }
+
     pub fn all_fields(&self) -> &[FieldDef] {
         &self.fields
     }

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -142,6 +142,22 @@ impl EntityDef {
                     .with_span(&input.ident)
             })?;
 
+        let owner_count = fields.iter().filter(|f| f.storage.is_owner).count();
+        if owner_count > 1 {
+            return Err(
+                darling::Error::custom("Entity can have at most one #[owner] field")
+                    .with_span(&input.ident)
+            );
+        }
+        if let Some(owner) = fields.iter().find(|f| f.storage.is_owner)
+            && owner.is_id()
+        {
+            return Err(darling::Error::custom(
+                "#[owner] cannot be combined with #[id]: the owner column scopes rows of another principal"
+            )
+            .with_span(&input.ident));
+        }
+
         if let Some(upsert) = &attrs.upsert {
             validate_upsert(
                 upsert,

--- a/crates/entity-derive-impl/src/entity/parse/entity/tests.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/tests.rs
@@ -461,3 +461,64 @@ fn upsert_unique_index_order_insensitive() {
     };
     assert!(EntityDef::from_derive_input(&input).is_ok());
 }
+
+#[test]
+fn owner_field_accessor_returns_marked_field() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "orders")]
+        pub struct Order {
+            #[id]
+            pub id: uuid::Uuid,
+            #[owner]
+            pub user_id: uuid::Uuid,
+            #[field(create, response)]
+            pub note: String,
+        }
+    };
+    let entity = EntityDef::from_derive_input(&input).unwrap();
+    assert_eq!(entity.owner_field().unwrap().name_str(), "user_id");
+}
+
+#[test]
+fn owner_duplicate_rejected() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "orders")]
+        pub struct Order {
+            #[id]
+            pub id: uuid::Uuid,
+            #[owner]
+            pub user_id: uuid::Uuid,
+            #[owner]
+            pub tenant_id: uuid::Uuid,
+        }
+    };
+    let err = EntityDef::from_derive_input(&input).unwrap_err();
+    assert!(err.to_string().contains("at most one #[owner]"));
+}
+
+#[test]
+fn owner_on_id_rejected() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "orders")]
+        pub struct Order {
+            #[id]
+            #[owner]
+            pub id: uuid::Uuid,
+        }
+    };
+    let err = EntityDef::from_derive_input(&input).unwrap_err();
+    assert!(err.to_string().contains("cannot be combined with #[id]"));
+}
+
+#[test]
+fn owner_absent_returns_none() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "users")]
+        pub struct User {
+            #[id]
+            pub id: uuid::Uuid,
+        }
+    };
+    let entity = EntityDef::from_derive_input(&input).unwrap();
+    assert!(entity.owner_field().is_none());
+}

--- a/crates/entity-derive-impl/src/entity/parse/field.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field.rs
@@ -170,6 +170,8 @@ impl FieldDef {
                 storage.is_id = true;
             } else if attr.path().is_ident("auto") {
                 storage.is_auto = true;
+            } else if attr.path().is_ident("owner") {
+                storage.is_owner = true;
             } else if attr.path().is_ident("field") {
                 expose = ExposeConfig::from_attr(attr);
             } else if attr.path().is_ident("belongs_to") {

--- a/crates/entity-derive-impl/src/entity/parse/field/storage.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/storage.rs
@@ -56,6 +56,12 @@ pub struct StorageConfig {
     /// - Typically used for `created_at`, `updated_at` timestamps
     pub is_auto: bool,
 
+    /// Ownership column (`#[owner]`).
+    ///
+    /// Marks the field carrying the owning principal's id. Enables
+    /// generated row-level scoped repository methods.
+    pub is_owner: bool,
+
     /// Foreign key relation (`#[belongs_to(Entity)]`).
     ///
     /// Stores the related entity name. When set, generates:
@@ -113,6 +119,7 @@ mod tests {
         let config = StorageConfig {
             is_id:      false,
             is_auto:    false,
+            is_owner:   false,
             belongs_to: Some(Ident::new("User", Span::call_site())),
             on_delete:  None
         };
@@ -124,6 +131,7 @@ mod tests {
         let config = StorageConfig {
             is_id:      false,
             is_auto:    false,
+            is_owner:   false,
             belongs_to: Some(Ident::new("User", Span::call_site())),
             on_delete:  Some(ReferentialAction::Cascade)
         };

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -866,3 +866,50 @@ mod tests {
         assert!(code.contains("bool"));
     }
 }
+
+#[cfg(test)]
+mod scoped_trait_tests {
+    use syn::{DeriveInput, parse_quote};
+
+    use super::*;
+    use crate::entity::parse::EntityDef;
+
+    #[test]
+    fn scoped_trait_methods_without_update_fields() {
+        let input: DeriveInput = parse_quote! {
+            #[entity(table = "orders")]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[owner]
+                pub user_id: uuid::Uuid,
+                #[field(create, response)]
+                pub note: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let code = generate(&entity).to_string();
+        assert!(code.contains("find_by_id_scoped"));
+        assert!(code.contains("list_by_owner"));
+        assert!(code.contains("delete_scoped"));
+        assert!(!code.contains("update_scoped"));
+    }
+
+    #[test]
+    fn scoped_trait_methods_with_update_fields() {
+        let input: DeriveInput = parse_quote! {
+            #[entity(table = "orders")]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[owner]
+                pub user_id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub note: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let code = generate(&entity).to_string();
+        assert!(code.contains("update_scoped"));
+    }
+}

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -98,6 +98,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     };
 
     let upsert_method = generate_upsert_method(entity);
+    let scoped_methods = generate_scoped_methods(entity, id_type);
     let relation_methods = generate_relation_methods(entity, id_type);
     let projection_methods = generate_projection_methods(entity, id_type);
     let soft_delete_methods = generate_soft_delete_methods(entity, id_type);
@@ -151,6 +152,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #projection_methods
 
             #soft_delete_methods
+
+            #scoped_methods
 
             #save_method
         }
@@ -436,6 +439,52 @@ fn generate_trait_method(def: &LookupMethodDef) -> TokenStream {
     quote! {
         #doc_comment
         async fn #method_name(&self, #param_name: #param_type) -> Result<#return_type, Self::Error>;
+    }
+}
+
+/// Generate ownership-scoped methods when an `#[owner]` field is present.
+///
+/// | Method | Purpose |
+/// |--------|---------|
+/// | `find_by_id_scoped` | Fetch a row only if it belongs to the owner |
+/// | `list_by_owner` | Paginated listing of the owner's rows |
+/// | `update_scoped` | Update only within the owner's rows (`None` = not theirs) |
+/// | `delete_scoped` | Delete only within the owner's rows |
+fn generate_scoped_methods(entity: &EntityDef, id_type: &syn::Type) -> TokenStream {
+    let Some(owner) = entity.owner_field() else {
+        return TokenStream::new();
+    };
+
+    let entity_name = entity.name();
+    let owner_name = owner.name();
+    let owner_type = owner.ty();
+    let update_dto = entity.ident_with("Update", "Request");
+
+    let update_method = if entity.update_fields().is_empty() {
+        TokenStream::new()
+    } else {
+        quote! {
+            /// Update the entity only if it belongs to the given owner.
+            ///
+            /// Returns `None` when no row matches the id/owner pair,
+            /// without revealing whether the row exists for another owner.
+            async fn update_scoped(&self, id: #id_type, #owner_name: #owner_type, dto: #update_dto) -> Result<Option<#entity_name>, Self::Error>;
+        }
+    };
+
+    quote! {
+        /// Find the entity only if it belongs to the given owner.
+        async fn find_by_id_scoped(&self, id: #id_type, #owner_name: #owner_type) -> Result<Option<#entity_name>, Self::Error>;
+
+        /// List entities belonging to the given owner.
+        async fn list_by_owner(&self, #owner_name: #owner_type, limit: i64, offset: i64) -> Result<Vec<#entity_name>, Self::Error>;
+
+        #update_method
+
+        /// Delete the entity only if it belongs to the given owner.
+        ///
+        /// Soft-delete aware. Returns `false` when no row matches.
+        async fn delete_scoped(&self, id: #id_type, #owner_name: #owner_type) -> Result<bool, Self::Error>;
     }
 }
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres.rs
@@ -68,6 +68,7 @@ mod projections;
 mod query;
 mod relations;
 mod save;
+mod scoped;
 mod soft_delete;
 mod upsert;
 
@@ -112,6 +113,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     let relation_impls = ctx.relation_methods();
     let projection_impls = ctx.projection_methods();
     let soft_delete_impls = ctx.soft_delete_methods();
+    let scoped_impls = ctx.scoped_methods();
     let lookup_impls = ctx.lookup_methods();
     let save_impl = ctx.save_method();
     let marker = marker::generated();
@@ -140,6 +142,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #relation_impls
             #projection_impls
             #soft_delete_impls
+            #scoped_impls
             #save_impl
         }
     }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
@@ -249,3 +249,32 @@ mod tests {
         assert!(code.contains("id = $2 AND user_id = $3 RETURNING *"));
     }
 }
+
+#[cfg(test)]
+mod no_update_fields_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::super::context::Context;
+    use crate::entity::parse::EntityDef;
+
+    #[test]
+    fn update_scoped_absent_without_update_fields() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "orders")]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[owner]
+                pub user_id: uuid::Uuid,
+                #[field(create, response)]
+                pub note: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let code = Context::new(&entity).scoped_methods().to_string();
+        assert!(code.contains("find_by_id_scoped"));
+        assert!(!code.contains("update_scoped"));
+        let _ = quote!();
+    }
+}

--- a/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Row-level ownership-scoped method generators for `PostgreSQL`.
+//!
+//! Generated from the `#[owner]` field attribute:
+//!
+//! | Method | SQL |
+//! |--------|-----|
+//! | `find_by_id_scoped` | `SELECT ... WHERE id = $1 AND owner = $2` |
+//! | `list_by_owner` | `SELECT ... WHERE owner = $1 ... LIMIT $2 OFFSET $3` |
+//! | `update_scoped` | `UPDATE ... WHERE id AND owner RETURNING *` |
+//! | `delete_scoped` | `DELETE ... WHERE id AND owner` (soft-delete aware) |
+//!
+//! All queries append `deleted_at IS NULL` when soft delete is enabled.
+//! Zero affected rows means "no such row for this owner" — surfaced as
+//! `None` / `false`, never leaking whether the row exists for someone
+//! else.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use super::{context::Context, helpers::update_bindings};
+use crate::utils::tracing::instrument;
+
+impl Context<'_> {
+    /// Generate all ownership-scoped method implementations.
+    ///
+    /// # Returns
+    ///
+    /// Empty `TokenStream` when the entity has no `#[owner]` field.
+    pub fn scoped_methods(&self) -> TokenStream {
+        let Some(owner) = self.entity.owner_field() else {
+            return TokenStream::new();
+        };
+
+        let Self {
+            entity_name,
+            row_name,
+            table,
+            columns_str,
+            id_name,
+            id_type,
+            soft_delete,
+            ..
+        } = self;
+
+        let owner_name = owner.name();
+        let owner_type = owner.ty();
+        let owner_col = owner.name_str();
+        let id_col = id_name.to_string();
+        let deleted_filter = if *soft_delete {
+            " AND deleted_at IS NULL"
+        } else {
+            ""
+        };
+
+        let find_sql = format!(
+            "SELECT {columns_str} FROM {table} WHERE {id_col} = $1 AND {owner_col} = $2{deleted_filter}"
+        );
+        let list_sql = format!(
+            "SELECT {columns_str} FROM {table} WHERE {owner_col} = $1{deleted_filter} \
+             ORDER BY {id_col} DESC LIMIT $2 OFFSET $3"
+        );
+        let delete_sql = if *soft_delete {
+            format!(
+                "UPDATE {table} SET deleted_at = NOW() WHERE {id_col} = $1 AND {owner_col} = $2 \
+                 AND deleted_at IS NULL"
+            )
+        } else {
+            format!("DELETE FROM {table} WHERE {id_col} = $1 AND {owner_col} = $2")
+        };
+
+        let find_span = instrument(&entity_name.to_string(), "find_by_id_scoped");
+        let list_span = instrument(&entity_name.to_string(), "list_by_owner");
+        let delete_span = instrument(&entity_name.to_string(), "delete_scoped");
+
+        let update_impl = self.update_scoped_method(&owner_col);
+
+        quote! {
+            #find_span
+            async fn find_by_id_scoped(
+                &self,
+                id: #id_type,
+                #owner_name: #owner_type,
+            ) -> Result<Option<#entity_name>, Self::Error> {
+                let row: Option<#row_name> = sqlx::query_as(#find_sql)
+                    .bind(&id)
+                    .bind(&#owner_name)
+                    .fetch_optional(self).await?;
+                Ok(row.map(#entity_name::from))
+            }
+
+            #list_span
+            async fn list_by_owner(
+                &self,
+                #owner_name: #owner_type,
+                limit: i64,
+                offset: i64,
+            ) -> Result<Vec<#entity_name>, Self::Error> {
+                let rows: Vec<#row_name> = sqlx::query_as(#list_sql)
+                    .bind(&#owner_name)
+                    .bind(limit)
+                    .bind(offset)
+                    .fetch_all(self).await?;
+                Ok(rows.into_iter().map(#entity_name::from).collect())
+            }
+
+            #delete_span
+            async fn delete_scoped(
+                &self,
+                id: #id_type,
+                #owner_name: #owner_type,
+            ) -> Result<bool, Self::Error> {
+                let result = sqlx::query(#delete_sql)
+                    .bind(&id)
+                    .bind(&#owner_name)
+                    .execute(self).await?;
+                Ok(result.rows_affected() > 0)
+            }
+
+            #update_impl
+        }
+    }
+
+    /// Generate `update_scoped` when the entity has update fields.
+    fn update_scoped_method(&self, owner_col: &str) -> TokenStream {
+        let update_fields = self.entity.update_fields();
+        if update_fields.is_empty() {
+            return TokenStream::new();
+        }
+
+        let Self {
+            entity_name,
+            row_name,
+            update_dto,
+            table,
+            id_name,
+            id_type,
+            dialect,
+            entity,
+            ..
+        } = self;
+
+        let owner = entity
+            .owner_field()
+            .expect("update_scoped_method is only called with an owner field");
+        let owner_name = owner.name();
+        let owner_type = owner.ty();
+
+        let field_names: Vec<String> = update_fields.iter().map(|f| f.name_str()).collect();
+        let field_refs: Vec<&str> = field_names.iter().map(String::as_str).collect();
+        let set_clause = dialect.set_clause(&field_refs);
+        let id_placeholder = update_fields.len() + 1;
+        let owner_placeholder = update_fields.len() + 2;
+        let bindings = update_bindings(&update_fields);
+
+        let sql = format!(
+            "UPDATE {table} SET {set_clause} WHERE {id_name} = ${id_placeholder} \
+             AND {owner_col} = ${owner_placeholder} RETURNING *",
+            id_name = id_name
+        );
+
+        let span = instrument(&entity_name.to_string(), "update_scoped");
+
+        quote! {
+            #span
+            async fn update_scoped(
+                &self,
+                id: #id_type,
+                #owner_name: #owner_type,
+                dto: #update_dto,
+            ) -> Result<Option<#entity_name>, Self::Error> {
+                let row: Option<#row_name> = sqlx::query_as(#sql)
+                    #(#bindings)*
+                    .bind(&id)
+                    .bind(&#owner_name)
+                    .fetch_optional(self).await?;
+                Ok(row.map(#entity_name::from))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::*;
+    use crate::entity::parse::EntityDef;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    fn owned_entity(extra: proc_macro2::TokenStream) -> EntityDef {
+        parse_entity(quote! {
+            #[entity(table = "orders" #extra)]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[owner]
+                pub user_id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub note: String,
+            }
+        })
+    }
+
+    #[test]
+    fn scoped_methods_generated_with_owner() {
+        let entity = owned_entity(quote!());
+        let code = Context::new(&entity).scoped_methods().to_string();
+        assert!(code.contains("find_by_id_scoped"));
+        assert!(code.contains("list_by_owner"));
+        assert!(code.contains("delete_scoped"));
+        assert!(code.contains("update_scoped"));
+        assert!(code.contains("user_id = $2"));
+    }
+
+    #[test]
+    fn scoped_methods_empty_without_owner() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users")]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub name: String,
+            }
+        });
+        assert!(Context::new(&entity).scoped_methods().is_empty());
+    }
+
+    #[test]
+    fn soft_delete_scopes_filter_deleted() {
+        let entity = owned_entity(quote!(, soft_delete));
+        let code = Context::new(&entity).scoped_methods().to_string();
+        assert!(code.contains("deleted_at IS NULL"));
+        assert!(code.contains("SET deleted_at = NOW()"));
+    }
+
+    #[test]
+    fn update_scoped_places_owner_after_id() {
+        let entity = owned_entity(quote!());
+        let code = Context::new(&entity).scoped_methods().to_string();
+        assert!(code.contains("id = $2 AND user_id = $3 RETURNING *"));
+    }
+}

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -469,8 +469,8 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(
     Entity,
     attributes(
-        entity, field, id, auto, validate, belongs_to, has_many, projection, filter, command,
-        example, column, map
+        entity, field, id, auto, owner, validate, belongs_to, has_many, projection, filter,
+        command, example, column, map
     )
 )]
 pub fn derive_entity(input: TokenStream) -> TokenStream {

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -74,7 +74,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.7" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.9", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.10", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/fail/owner_duplicate.rs
+++ b/crates/entity-derive/tests/cases/fail/owner_duplicate.rs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Entity)]
+#[entity(table = "orders")]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+
+    #[owner]
+    pub user_id: Uuid,
+
+    #[owner]
+    pub tenant_id: Uuid,
+
+    #[field(create, response)]
+    pub note: String,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/owner_duplicate.stderr
+++ b/crates/entity-derive/tests/cases/fail/owner_duplicate.stderr
@@ -1,0 +1,5 @@
+error: Entity can have at most one #[owner] field
+ --> tests/cases/fail/owner_duplicate.rs:9:12
+  |
+9 | pub struct Order {
+  |            ^^^^^

--- a/crates/entity-derive/tests/cases/fail/owner_on_id.rs
+++ b/crates/entity-derive/tests/cases/fail/owner_on_id.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Entity)]
+#[entity(table = "orders")]
+pub struct Order {
+    #[id]
+    #[owner]
+    pub id: Uuid,
+
+    #[field(create, response)]
+    pub note: String,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/owner_on_id.stderr
+++ b/crates/entity-derive/tests/cases/fail/owner_on_id.stderr
@@ -1,0 +1,5 @@
+error: #[owner] cannot be combined with #[id]: the owner column scopes rows of another principal
+ --> tests/cases/fail/owner_on_id.rs:9:12
+  |
+9 | pub struct Order {
+  |            ^^^^^

--- a/crates/entity-derive/tests/cases/pass/owner_scoped.rs
+++ b/crates/entity-derive/tests/cases/pass/owner_scoped.rs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Entity)]
+#[entity(table = "orders", soft_delete)]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+
+    #[owner]
+    pub user_id: Uuid,
+
+    #[field(create, update, response)]
+    pub note: String,
+
+    pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+fn assert_scoped_signatures() {
+    fn requires_scoped<R>()
+    where
+        R: OrderRepository + ?Sized
+    {
+    }
+
+    requires_scoped::<sqlx::PgPool>();
+}
+
+async fn exercise(pool: sqlx::PgPool, id: Uuid, user: Uuid) -> Result<(), sqlx::Error> {
+    let _found: Option<Order> = pool.find_by_id_scoped(id, user).await?;
+    let _mine: Vec<Order> = pool.list_by_owner(user, 10, 0).await?;
+    let _updated: Option<Order> = pool
+        .update_scoped(id, user, UpdateOrderRequest::default())
+        .await?;
+    let _gone: bool = pool.delete_scoped(id, user).await?;
+    Ok(())
+}
+
+fn main() {
+    assert_scoped_signatures();
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #145.

Adds the `#[owner]` field attribute generating row-level scoped repository methods.

## Attribute

```rust
#[derive(Entity)]
#[entity(table = "orders")]
pub struct Order {
    #[id] pub id: Uuid,
    #[owner] pub user_id: Uuid,
    #[field(create, update, response)] pub note: String,
}
```

## Generated methods

- `find_by_id_scoped(id, owner) -> Option<Entity>` — `WHERE id = $1 AND owner = $2`
- `list_by_owner(owner, limit, offset) -> Vec<Entity>`
- `update_scoped(id, owner, dto) -> Option<Entity>` (generated when update fields exist)
- `delete_scoped(id, owner) -> bool` — soft-delete aware (`SET deleted_at` when enabled)

Zero matched rows surface as `None` / `false` without revealing whether the row exists for another owner. All scoped queries append `deleted_at IS NULL` under `soft_delete`. SQL is assembled at expansion time (static strings).

## Validation

- at most one `#[owner]` field; `#[owner]` + `#[id]` combination rejected — both with clear compile errors

## Testing

- 8 new unit tests (accessor, validation branches, SQL generation incl. soft-delete and placeholder ordering) — 627 total green
- trybuild: pass case exercising all four methods against `PgPool`, 2 fail cases with pinned stderr
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: field quick-reference + "Ownership Scoping" section + features table, pins 0.12
- entity-derive 0.11.0 → 0.12.0, entity-derive-impl 0.9.0 → 0.10.0
- Wiki follows after merge