### PR TITLE
142

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.8" }
-entity-derive = { path = "crates/entity-derive", version = "0.13" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.11" }
+entity-derive = { path = "crates/entity-derive", version = "0.14" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.12" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.13", features = ["postgres", "api"] }
+entity-derive = { version = "0.14", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.13", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.14", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.13", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.14", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -131,7 +131,7 @@ tracing-subscriber = "0.3"
 | **Auto HTTP Handlers** | `api(handlers)` generates CRUD endpoints + router |
 | **`OpenAPI` Docs** | Auto-generated Swagger/OpenAPI documentation |
 | **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]` |
-| **Relations** | `#[belongs_to]` and `#[has_many]` |
+| **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
 | **Aggregate Roots** | `#[entity(aggregate_root)]` with `New{T}` DTOs and transactional `save` |
@@ -215,6 +215,7 @@ tracing-subscriber = "0.3"
 #[filter(range)]               // Range filter (from/to)
 #[belongs_to(Entity)]          // Foreign key relation
 #[has_many(Entity)]            // One-to-many relation
+#[has_many(E, through = "t")]  // Many-to-many via junction table
 #[projection(Name: fields)]    // Partial view
 ```
 
@@ -308,6 +309,28 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Many-to-Many Relations
+
+Declare the junction table with `through` and the repository gains a
+JOIN-backed lookup plus link management, while `migrations` emits the
+junction DDL (composite primary key, cascading foreign keys):
+
+```rust,ignore
+#[derive(Entity)]
+#[entity(table = "teams", migrations)]
+#[has_many(User, through = "team_members")]
+pub struct Team { /* ... */ }
+
+for ddl in Team::MIGRATION_JUNCTIONS {
+    sqlx::query(ddl).execute(&pool).await?;
+}
+
+pool.add_user(team_id, user_id).await?;          // idempotent link
+let members: Vec<User> = pool.find_users(team_id).await?;
+let linked = pool.has_user(team_id, user_id).await?;
+let removed = pool.remove_user(team_id, user_id).await?;
+```
 
 ### Postgres Enums
 
@@ -406,7 +429,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.13", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.14", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.11.0"
+version = "0.12.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/migrations/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres.rs
@@ -7,6 +7,7 @@
 
 mod ddl;
 
+use convert_case::Casing;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Type;
@@ -72,6 +73,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         .collect();
 
     let outbox_const = outbox_migration_const(entity);
+    let junctions_const = junction_migration_const(entity);
     let marker = marker::generated();
 
     quote! {
@@ -105,6 +107,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #vis const MIGRATION_TYPES: &'static [&'static str] = &[#(#create_type_refs),*];
 
             #outbox_const
+
+            #junctions_const
         }
 
         const _: () = {
@@ -143,6 +147,61 @@ fn outbox_migration_const(entity: &EntityDef) -> TokenStream {
         /// Execute alongside [`Self::MIGRATION_UP`]. Safe to run once
         /// per outbox-enabled entity — the statements are `IF NOT EXISTS`.
         #vis const MIGRATION_OUTBOX: &'static str = #ddl;
+    }
+}
+
+/// Generate the `MIGRATION_JUNCTIONS` constant for many-to-many relations.
+///
+/// One idempotent `CREATE TABLE IF NOT EXISTS` statement per
+/// `#[has_many(Child, through = "...")]` declaration: composite primary
+/// key over both foreign keys, `ON DELETE CASCADE` on each side. The
+/// child id column type mirrors the parent's `#[id]` type.
+fn junction_migration_const(entity: &EntityDef) -> TokenStream {
+    let through: Vec<_> = entity
+        .has_many_relations()
+        .iter()
+        .filter_map(|r| r.through.as_ref().map(|j| (r, j)))
+        .collect();
+    if through.is_empty() {
+        return TokenStream::new();
+    }
+
+    let vis = &entity.vis;
+    let mapper = crate::entity::migrations::types::PostgresTypeMapper;
+    let id_field = entity.id_field();
+    let id_sql = crate::entity::migrations::types::TypeMapper::map_type(
+        &mapper,
+        id_field.ty(),
+        &Default::default()
+    )
+    .name;
+    let parent_snake = entity.name_str().to_case(convert_case::Case::Snake);
+    let parent_table = entity.full_table_name();
+
+    let ddls: Vec<String> = through
+        .iter()
+        .map(|(relation, junction)| {
+            let child_snake = relation
+                .entity
+                .to_string()
+                .to_case(convert_case::Case::Snake);
+            let child_table = entity.full_table_name_for(&format!("{child_snake}s"));
+            let junction_table = entity.full_table_name_for(junction);
+            format!(
+                "CREATE TABLE IF NOT EXISTS {junction_table} (\
+                     {parent_snake}_id {id_sql} NOT NULL REFERENCES {parent_table}(id) ON DELETE CASCADE, \
+                     {child_snake}_id {id_sql} NOT NULL REFERENCES {child_table}(id) ON DELETE CASCADE, \
+                     PRIMARY KEY ({parent_snake}_id, {child_snake}_id)\
+                 );"
+            )
+        })
+        .collect();
+
+    quote! {
+        /// Idempotent DDL for many-to-many junction tables.
+        ///
+        /// Execute after [`Self::MIGRATION_UP`] of both related tables.
+        #vis const MIGRATION_JUNCTIONS: &'static [&'static str] = &[#(#ddls),*];
     }
 }
 
@@ -222,5 +281,53 @@ mod pg_enum_tests {
         let code = generate(&entity).to_string();
         assert!(code.contains("OrderStatus > :: PG_CREATE_TYPE"));
         assert!(!code.contains("Option < OrderStatus > :: PG_CREATE_TYPE"));
+    }
+}
+
+#[cfg(test)]
+mod junction_tests {
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn team_entity() -> EntityDef {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "teams", migrations)]
+            #[has_many(User, through = "team_members")]
+            pub struct Team {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub name: String,
+            }
+        };
+        EntityDef::from_derive_input(&input).unwrap()
+    }
+
+    #[test]
+    fn junction_ddl_emitted_for_through() {
+        let code = generate(&team_entity()).to_string();
+        assert!(code.contains("MIGRATION_JUNCTIONS"));
+        assert!(code.contains("CREATE TABLE IF NOT EXISTS team_members"));
+        assert!(code.contains("team_id UUID NOT NULL REFERENCES teams(id) ON DELETE CASCADE"));
+        assert!(code.contains("user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE"));
+        assert!(code.contains("PRIMARY KEY (team_id, user_id)"));
+    }
+
+    #[test]
+    fn junction_const_absent_for_plain_has_many() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "teams", migrations)]
+            #[has_many(User)]
+            pub struct Team {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub name: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let code = generate(&entity).to_string();
+        assert!(!code.contains("MIGRATION_JUNCTIONS"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/parse.rs
+++ b/crates/entity-derive-impl/src/entity/parse.rs
@@ -120,7 +120,7 @@ mod uuid_version;
 pub use api::ApiConfig;
 pub use command::{CommandDef, CommandKindHint, CommandSource};
 pub use dialect::DatabaseDialect;
-pub use entity::{CompositeIndexDef, EntityDef, ProjectionDef, UpsertAction};
+pub use entity::{CompositeIndexDef, EntityDef, HasManyDef, ProjectionDef, UpsertAction};
 #[allow(unused_imports)] // Will be used for OpenAPI schema examples (#80)
 pub use field::ExampleValue;
 #[allow(unused_imports)] // Re-exported for migration generation tests

--- a/crates/entity-derive-impl/src/entity/parse/entity.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity.rs
@@ -148,6 +148,7 @@ mod upsert;
 
 pub use attrs::EntityAttrs;
 pub use def::EntityDef;
+pub use helpers::HasManyDef;
 pub use index::CompositeIndexDef;
 pub use projection::{ProjectionDef, parse_projection_attrs};
 pub use upsert::UpsertAction;

--- a/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
@@ -154,7 +154,7 @@ impl EntityDef {
     ///
     /// Returns entity identifiers for one-to-many relationships.
     /// Used to generate collection methods in the repository.
-    pub fn has_many_relations(&self) -> &[Ident] {
+    pub fn has_many_relations(&self) -> &[super::HasManyDef] {
         &self.has_many
     }
 

--- a/crates/entity-derive-impl/src/entity/parse/entity/def.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/def.rs
@@ -64,6 +64,7 @@ use super::{
         returning::ReturningMode, sql_level::SqlLevel, uuid_version::UuidVersion
     },
     CompositeIndexDef, ProjectionDef,
+    helpers::HasManyDef,
     upsert::UpsertDef
 };
 
@@ -139,7 +140,7 @@ pub struct EntityDef {
     /// Has-many relations defined via `#[has_many(Entity)]`.
     ///
     /// Each entry is the related entity name.
-    pub has_many: Vec<Ident>,
+    pub has_many: Vec<HasManyDef>,
 
     /// Projections defined via `#[projection(Name: field1, field2)]`.
     ///

--- a/crates/entity-derive-impl/src/entity/parse/entity/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/helpers.rs
@@ -90,12 +90,48 @@ use super::{
 ///
 /// // Returns: vec![Ident("Post"), Ident("Comment")]
 /// ```
-pub fn parse_has_many_attrs(attrs: &[Attribute]) -> Vec<Ident> {
+pub fn parse_has_many_attrs(attrs: &[Attribute]) -> Vec<HasManyDef> {
     attrs
         .iter()
         .filter(|attr| attr.path().is_ident("has_many"))
-        .filter_map(|attr| attr.parse_args::<Ident>().ok())
+        .filter_map(|attr| {
+            attr.parse_args_with(|input: syn::parse::ParseStream<'_>| {
+                let entity: Ident = input.parse()?;
+                let mut through = None;
+                if input.peek(syn::Token![,]) {
+                    let _: syn::Token![,] = input.parse()?;
+                    let key: Ident = input.parse()?;
+                    if key != "through" {
+                        return Err(syn::Error::new(
+                            key.span(),
+                            "unknown has_many option; expected `through = \"junction_table\"`"
+                        ));
+                    }
+                    let _: syn::Token![=] = input.parse()?;
+                    let table: syn::LitStr = input.parse()?;
+                    through = Some(table.value());
+                }
+                Ok(HasManyDef {
+                    entity,
+                    through
+                })
+            })
+            .ok()
+        })
         .collect()
+}
+
+/// One `#[has_many(...)]` relation declaration.
+#[derive(Debug, Clone)]
+pub struct HasManyDef {
+    /// Related entity type name.
+    pub entity: Ident,
+
+    /// Junction table for many-to-many relations.
+    ///
+    /// `None` means a plain one-to-many relation over a
+    /// `{parent}_id` foreign key on the child table.
+    pub through: Option<String>
 }
 
 /// Parse `api(...)` from `#[entity(...)]` attribute.
@@ -279,7 +315,7 @@ mod tests {
         let attrs: Vec<syn::Attribute> = vec![parse_quote!(#[has_many(Post)])];
         let result = parse_has_many_attrs(&attrs);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].to_string(), "Post");
+        assert_eq!(result[0].entity.to_string(), "Post");
     }
 
     #[test]
@@ -291,9 +327,34 @@ mod tests {
         ];
         let result = parse_has_many_attrs(&attrs);
         assert_eq!(result.len(), 3);
-        assert_eq!(result[0].to_string(), "Post");
-        assert_eq!(result[1].to_string(), "Comment");
-        assert_eq!(result[2].to_string(), "Like");
+        assert_eq!(result[0].entity.to_string(), "Post");
+        assert_eq!(result[1].entity.to_string(), "Comment");
+        assert_eq!(result[2].entity.to_string(), "Like");
+    }
+
+    #[test]
+    fn has_many_through_parsed() {
+        let attrs: Vec<syn::Attribute> =
+            vec![parse_quote!(#[has_many(User, through = "team_members")])];
+        let result = parse_has_many_attrs(&attrs);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].entity.to_string(), "User");
+        assert_eq!(result[0].through.as_deref(), Some("team_members"));
+    }
+
+    #[test]
+    fn has_many_plain_has_no_through() {
+        let attrs: Vec<syn::Attribute> = vec![parse_quote!(#[has_many(Post)])];
+        let result = parse_has_many_attrs(&attrs);
+        assert!(result[0].through.is_none());
+    }
+
+    #[test]
+    fn has_many_unknown_option_skipped() {
+        let attrs: Vec<syn::Attribute> =
+            vec![parse_quote!(#[has_many(User, via = "team_members")])];
+        let result = parse_has_many_attrs(&attrs);
+        assert!(result.is_empty());
     }
 
     #[test]
@@ -305,7 +366,7 @@ mod tests {
         ];
         let result = parse_has_many_attrs(&attrs);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].to_string(), "Post");
+        assert_eq!(result[0].entity.to_string(), "Post");
     }
 
     // =========================================================================

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -201,22 +201,54 @@ fn generate_belongs_to_method(field: &FieldDef, id_type: &syn::Type) -> Option<T
     })
 }
 
-/// Generate a `find_{entities}` method for a `has_many` relation.
+/// Generate methods for a `has_many` relation.
+///
+/// Plain relations get `find_{child}s`; `through = "..."` relations
+/// additionally get `add_{child}` / `remove_{child}` / `has_{child}`
+/// junction management methods.
 fn generate_has_many_method(
     entity: &EntityDef,
-    related: &syn::Ident,
+    relation: &crate::entity::parse::HasManyDef,
     id_type: &syn::Type
 ) -> TokenStream {
+    let related = &relation.entity;
     let related_snake = related.to_string().to_case(Case::Snake);
     let method_name = format_ident!("find_{}s", related_snake);
     let entity_snake = entity.name_str().to_case(Case::Snake);
     let fk_field = format_ident!("{}_id", entity_snake);
 
-    quote! {
+    let find_method = quote! {
         /// Find all related entities for this parent.
         ///
-        /// The foreign key field is assumed to be `{parent}_id`.
+        /// The foreign key field is assumed to be `{parent}_id`; for
+        /// `through` relations the lookup joins the junction table.
         async fn #method_name(&self, #fk_field: #id_type) -> Result<Vec<#related>, Self::Error>;
+    };
+
+    if relation.through.is_none() {
+        return find_method;
+    }
+
+    let add_name = format_ident!("add_{}", related_snake);
+    let remove_name = format_ident!("remove_{}", related_snake);
+    let has_name = format_ident!("has_{}", related_snake);
+    let child_id = format_ident!("{}_id", related_snake);
+
+    quote! {
+        #find_method
+
+        /// Link a related entity through the junction table.
+        ///
+        /// Idempotent: linking an already-linked pair is a no-op.
+        async fn #add_name(&self, #fk_field: #id_type, #child_id: #id_type) -> Result<(), Self::Error>;
+
+        /// Unlink a related entity from the junction table.
+        ///
+        /// Returns `false` when the pair was not linked.
+        async fn #remove_name(&self, #fk_field: #id_type, #child_id: #id_type) -> Result<bool, Self::Error>;
+
+        /// Check whether the pair is linked in the junction table.
+        async fn #has_name(&self, #fk_field: #id_type, #child_id: #id_type) -> Result<bool, Self::Error>;
     }
 }
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres/relations.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/relations.rs
@@ -101,7 +101,8 @@ impl Context<'_> {
     /// ```sql
     /// SELECT * FROM {schema}.{child}s WHERE {parent}_id = $1
     /// ```
-    fn has_many_method(&self, related: &syn::Ident) -> TokenStream {
+    fn has_many_method(&self, relation: &crate::entity::parse::HasManyDef) -> TokenStream {
+        let related = &relation.entity;
         let related_snake = related.to_string().to_case(Case::Snake);
         let method_name = format_ident!("find_{}s", related_snake);
         let related_row = format_ident!("{}Row", related);
@@ -113,6 +114,65 @@ impl Context<'_> {
         let id_type = self.id_type;
         let placeholder = self.dialect.placeholder(1);
 
+        if let Some(junction) = &relation.through {
+            let junction_table = self.entity.full_table_name_for(junction);
+            let find_sql = format!(
+                "SELECT c.* FROM {related_table} c \
+                 INNER JOIN {junction_table} j ON j.{related_snake}_id = c.id \
+                 WHERE j.{entity_snake}_id = $1"
+            );
+            let add_sql = format!(
+                "INSERT INTO {junction_table} ({entity_snake}_id, {related_snake}_id) \
+                 VALUES ($1, $2) ON CONFLICT DO NOTHING"
+            );
+            let remove_sql = format!(
+                "DELETE FROM {junction_table} \
+                 WHERE {entity_snake}_id = $1 AND {related_snake}_id = $2"
+            );
+            let has_sql = format!(
+                "SELECT EXISTS(SELECT 1 FROM {junction_table} \
+                 WHERE {entity_snake}_id = $1 AND {related_snake}_id = $2)"
+            );
+
+            let add_name = format_ident!("add_{}", related_snake);
+            let remove_name = format_ident!("remove_{}", related_snake);
+            let has_name = format_ident!("has_{}", related_snake);
+            let child_id = format_ident!("{}_id", related_snake);
+
+            return quote! {
+                async fn #method_name(&self, #fk_field: #id_type) -> Result<Vec<#related>, Self::Error> {
+                    let rows: Vec<#related_row> = sqlx::query_as(#find_sql)
+                        .bind(&#fk_field)
+                        .fetch_all(self).await?;
+                    Ok(rows.into_iter().map(#related::from).collect())
+                }
+
+                async fn #add_name(&self, #fk_field: #id_type, #child_id: #id_type) -> Result<(), Self::Error> {
+                    sqlx::query(#add_sql)
+                        .bind(&#fk_field)
+                        .bind(&#child_id)
+                        .execute(self).await?;
+                    Ok(())
+                }
+
+                async fn #remove_name(&self, #fk_field: #id_type, #child_id: #id_type) -> Result<bool, Self::Error> {
+                    let result = sqlx::query(#remove_sql)
+                        .bind(&#fk_field)
+                        .bind(&#child_id)
+                        .execute(self).await?;
+                    Ok(result.rows_affected() > 0)
+                }
+
+                async fn #has_name(&self, #fk_field: #id_type, #child_id: #id_type) -> Result<bool, Self::Error> {
+                    let exists: bool = sqlx::query_scalar(#has_sql)
+                        .bind(&#fk_field)
+                        .bind(&#child_id)
+                        .fetch_one(self).await?;
+                    Ok(exists)
+                }
+            };
+        }
+
         quote! {
             async fn #method_name(&self, #fk_field: #id_type) -> Result<Vec<#related>, Self::Error> {
                 let rows: Vec<#related_row> = sqlx::query_as(
@@ -121,5 +181,59 @@ impl Context<'_> {
                 Ok(rows.into_iter().map(#related::from).collect())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod through_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::super::context::Context;
+    use crate::entity::parse::EntityDef;
+
+    fn team_entity() -> EntityDef {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "teams")]
+            #[has_many(User, through = "team_members")]
+            pub struct Team {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub name: String,
+            }
+        };
+        EntityDef::from_derive_input(&input).unwrap()
+    }
+
+    #[test]
+    fn through_relation_generates_junction_methods() {
+        let entity = team_entity();
+        let code = Context::new(&entity).relation_methods().to_string();
+        assert!(code.contains("find_users"));
+        assert!(code.contains("add_user"));
+        assert!(code.contains("remove_user"));
+        assert!(code.contains("has_user"));
+        assert!(code.contains("INNER JOIN team_members j ON j.user_id = c.id"));
+        assert!(code.contains("ON CONFLICT DO NOTHING"));
+        let _ = quote!();
+    }
+
+    #[test]
+    fn plain_relation_has_no_junction_methods() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "teams")]
+            #[has_many(User)]
+            pub struct Team {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub name: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let code = Context::new(&entity).relation_methods().to_string();
+        assert!(code.contains("find_users"));
+        assert!(!code.contains("add_user"));
     }
 }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.8" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.11", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.12", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/has_many_through.rs
+++ b/crates/entity-derive/tests/cases/pass/has_many_through.rs
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "users")]
+pub struct User {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "teams", migrations)]
+#[has_many(User, through = "team_members")]
+pub struct Team {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub name: String,
+}
+
+async fn exercise(pool: sqlx::PgPool, team: Uuid, user: Uuid) -> Result<(), sqlx::Error> {
+    pool.add_user(team, user).await?;
+    let members: Vec<User> = pool.find_users(team).await?;
+    let linked: bool = pool.has_user(team, user).await?;
+    let removed: bool = pool.remove_user(team, user).await?;
+    let _ = (members, linked, removed);
+    Ok(())
+}
+
+fn main() {
+    assert_eq!(Team::MIGRATION_JUNCTIONS.len(), 1);
+    assert!(Team::MIGRATION_JUNCTIONS[0].contains("team_members"));
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #142.

Adds many-to-many support: `#[has_many(User, through = "team_members")]`.

## Generated

- `find_users(team_id) -> Vec<User>` — INNER JOIN over the junction table
- `add_user(team_id, user_id)` — idempotent link (`ON CONFLICT DO NOTHING`)
- `remove_user(team_id, user_id) -> bool` — unlink, `false` when not linked
- `has_user(team_id, user_id) -> bool` — `SELECT EXISTS`
- `{Entity}::MIGRATION_JUNCTIONS` — idempotent junction DDL: composite PK over both FKs, `ON DELETE CASCADE` both sides, id column type mirrored from the parent's `#[id]`

Plain `#[has_many(Entity)]` is unchanged. All through-SQL is assembled at expansion time (static strings). Unknown `has_many` options are rejected.

## Testing

- 7 new unit tests (parser through/plain/unknown-option, JOIN/link codegen, junction DDL shape, absence for plain relations) — 641 total green
- trybuild pass case: two entities, all four junction methods exercised against `PgPool`, DDL asserted
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: field quick-reference, new "Many-to-Many Relations" section, features table, pins 0.14
- entity-derive 0.13.0 → 0.14.0, entity-derive-impl 0.11.0 → 0.12.0
- Wiki (Relations ×5) follows after merge