### PR TITLE
147

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.8" }
-entity-derive = { path = "crates/entity-derive", version = "0.14" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.12" }
+entity-derive = { path = "crates/entity-derive", version = "0.15" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.13" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.14", features = ["postgres", "api"] }
+entity-derive = { version = "0.15", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.14", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.15", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.14", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.15", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -131,6 +131,7 @@ tracing-subscriber = "0.3"
 | **Auto HTTP Handlers** | `api(handlers)` generates CRUD endpoints + router |
 | **`OpenAPI` Docs** | Auto-generated Swagger/OpenAPI documentation |
 | **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]` |
+| **Sorting & Keyset** | `#[sort]` whitelisted ORDER BY + `list_after` cursor pagination |
 | **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
@@ -213,6 +214,7 @@ tracing-subscriber = "0.3"
 #[filter]                      // Exact match filter
 #[filter(like)]                // ILIKE pattern filter
 #[filter(range)]               // Range filter (from/to)
+#[sort]                        // Whitelisted dynamic ORDER BY
 #[belongs_to(Entity)]          // Foreign key relation
 #[has_many(Entity)]            // One-to-many relation
 #[has_many(E, through = "t")]  // Many-to-many via junction table
@@ -309,6 +311,29 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Sorting & Keyset Pagination
+
+Mark sortable columns with `#[sort]` — the Query struct gains a
+whitelisted sort selector (`{Entity}SortField`, one `Asc`/`Desc` variant
+per column, JSON-friendly), so user input can never inject SQL. Every
+repository also gets `list_after` keyset pagination that stays fast on
+deep pages, unlike OFFSET:
+
+```rust,ignore
+let query = PostQuery {
+    sort: Some(PostSortField::ViewsDesc),
+    limit: Some(20),
+    ..Default::default()
+};
+let top: Vec<Post> = pool.query(query).await?;
+
+let page: Vec<Post> = pool.list_after(None, 20).await?;
+let next: Vec<Post> = pool.list_after(page.last().map(|p| p.id), 20).await?;
+```
+
+With the default UUIDv7 ids, the id-ordered keyset walk is
+chronologically stable.
 
 ### Many-to-Many Relations
 
@@ -429,7 +454,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.14", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.15", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.12.0"
+version = "0.13.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
@@ -144,6 +144,18 @@ impl EntityDef {
     }
 
     /// Check if this entity has any filterable fields.
+    /// Get all fields marked `#[sort]`.
+    #[must_use]
+    pub fn sort_fields(&self) -> Vec<&FieldDef> {
+        self.fields.iter().filter(|f| f.sortable).collect()
+    }
+
+    /// Check if the entity has any `#[sort]` fields.
+    #[must_use]
+    pub fn has_sort_fields(&self) -> bool {
+        self.fields.iter().any(|f| f.sortable)
+    }
+
     pub fn has_filters(&self) -> bool {
         self.fields
             .iter()

--- a/crates/entity-derive-impl/src/entity/parse/field.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field.rs
@@ -103,6 +103,9 @@ pub struct FieldDef {
     pub ty: Type,
 
     /// DTO exposure configuration.
+    /// Whether the field is marked `#[sort]` (dynamic ORDER BY).
+    pub sortable: bool,
+
     pub expose: ExposeConfig,
 
     /// Database storage configuration.
@@ -159,6 +162,7 @@ impl FieldDef {
         let validation = validation::parse_validation_attrs(&field.attrs);
         let example = example::parse_example_attr(&field.attrs);
 
+        let mut sortable = false;
         let mut expose = ExposeConfig::default();
         let mut storage = StorageConfig::default();
         let mut filter = FilterConfig::default();
@@ -172,6 +176,8 @@ impl FieldDef {
                 storage.is_auto = true;
             } else if attr.path().is_ident("owner") {
                 storage.is_owner = true;
+            } else if attr.path().is_ident("sort") {
+                sortable = true;
             } else if attr.path().is_ident("field") {
                 expose = ExposeConfig::from_attr(attr);
             } else if attr.path().is_ident("belongs_to") {
@@ -192,6 +198,7 @@ impl FieldDef {
         Ok(Self {
             ident,
             ty,
+            sortable,
             expose,
             storage,
             filter,

--- a/crates/entity-derive-impl/src/entity/query.rs
+++ b/crates/entity-derive-impl/src/entity/query.rs
@@ -51,7 +51,7 @@ use crate::utils::marker;
 ///
 /// Returns an empty `TokenStream` if no fields have `#[filter]`.
 pub fn generate(entity: &EntityDef) -> TokenStream {
-    if !entity.has_filters() {
+    if !entity.has_filters() && !entity.has_sort_fields() {
         return TokenStream::new();
     }
 
@@ -88,12 +88,17 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     let filter_name = entity.ident_with("", "Filter");
 
+    let (sort_enum, sort_field) = generate_sort_enum(entity);
+
     quote! {
+        #sort_enum
+
         #marker
         #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
         #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
         #vis struct #query_name {
             #(#field_defs,)*
+            #sort_field
             /// Maximum number of results to return.
             pub limit: Option<i64>,
             /// Number of results to skip.
@@ -102,5 +107,146 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
         /// Type alias for filter operations (same as Query).
         #vis type #filter_name = #query_name;
+    }
+}
+
+/// Generate the `{Entity}SortField` enum and the Query `sort` field.
+///
+/// One `Asc`/`Desc` variant pair per `#[sort]` field. `order_by()`
+/// returns a whitelisted static `ORDER BY` fragment, so user input can
+/// never inject SQL — unknown values simply fail deserialization.
+fn generate_sort_enum(entity: &EntityDef) -> (TokenStream, TokenStream) {
+    let sort_fields = entity.sort_fields();
+    if sort_fields.is_empty() {
+        return (TokenStream::new(), TokenStream::new());
+    }
+
+    let vis = &entity.vis;
+    let sort_name = entity.ident_with("", "SortField");
+
+    let mut variants = Vec::new();
+    let mut arms = Vec::new();
+    for field in &sort_fields {
+        let column = field.name_str();
+        for (suffix, direction) in [("Asc", "ASC"), ("Desc", "DESC")] {
+            let variant = format_ident!(
+                "{}{}",
+                convert_case::Casing::to_case(&column, convert_case::Case::Pascal),
+                suffix
+            );
+            let fragment = format!("{column} {direction}");
+            variants.push(quote! { #variant });
+            arms.push(quote! { Self::#variant => #fragment });
+        }
+    }
+
+    let doc = format!("Sortable columns for [`{}`] queries.", entity.name());
+    let marker = marker::generated();
+
+    let sort_enum = quote! {
+        #marker
+        #[doc = #doc]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+        #[serde(rename_all = "snake_case")]
+        #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
+        #vis enum #sort_name {
+            #(#variants,)*
+        }
+
+        impl #sort_name {
+            /// Whitelisted `ORDER BY` fragment for this sort selection.
+            #vis fn order_by(&self) -> &'static str {
+                match self {
+                    #(#arms,)*
+                }
+            }
+        }
+    };
+
+    let sort_field = quote! {
+        /// Dynamic sort selection (whitelisted columns only).
+        pub sort: Option<#sort_name>,
+    };
+
+    (sort_enum, sort_field)
+}
+
+#[cfg(test)]
+mod sort_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    fn sortable_entity() -> EntityDef {
+        parse_entity(quote! {
+            #[entity(table = "posts")]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                #[sort]
+                pub title: String,
+                #[field(create, response)]
+                #[sort]
+                #[filter]
+                pub views: i64,
+            }
+        })
+    }
+
+    #[test]
+    fn sort_enum_generated_with_asc_desc_variants() {
+        let code = generate(&sortable_entity()).to_string();
+        assert!(code.contains("enum PostSortField"));
+        assert!(code.contains("TitleAsc"));
+        assert!(code.contains("TitleDesc"));
+        assert!(code.contains("ViewsDesc"));
+        assert!(code.contains("\"title ASC\""));
+        assert!(code.contains("\"views DESC\""));
+    }
+
+    #[test]
+    fn query_struct_gains_sort_field() {
+        let code = generate(&sortable_entity()).to_string();
+        assert!(code.contains("pub sort : Option < PostSortField >"));
+    }
+
+    #[test]
+    fn sort_only_entity_still_generates_query() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "posts")]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[sort]
+                pub title: String,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(code.contains("struct PostQuery"));
+        assert!(code.contains("PostSortField"));
+    }
+
+    #[test]
+    fn no_sort_no_enum() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "posts")]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[filter]
+                pub title: String,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(!code.contains("SortField"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -141,6 +141,14 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
             async fn list(&self, limit: i64, offset: i64) -> Result<Vec<#entity_name>, Self::Error>;
 
+            /// List entities after the given cursor (keyset pagination).
+            ///
+            /// Rows are ordered by id descending; pass the id of the last
+            /// row from the previous page as the cursor. With the default
+            /// UUIDv7 ids this is a stable time-ordered walk that does not
+            /// degrade on deep pages the way OFFSET does.
+            async fn list_after(&self, cursor: Option<#id_type>, limit: i64) -> Result<Vec<#entity_name>, Self::Error>;
+
             #query_method
 
             #stream_method
@@ -323,7 +331,7 @@ fn generate_soft_delete_methods(entity: &EntityDef, id_type: &syn::Type) -> Toke
 /// async fn query(&self, query: UserQuery) -> Result<Vec<User>, Self::Error>;
 /// ```
 fn generate_query_method(entity: &EntityDef) -> TokenStream {
-    if !entity.has_filters() {
+    if !entity.has_filters() && !entity.has_sort_fields() {
         return TokenStream::new();
     }
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres.rs
@@ -109,6 +109,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     let update_impl = ctx.update_method();
     let delete_impl = ctx.delete_method();
     let list_impl = ctx.list_method();
+    let list_after_impl = ctx.list_after_method();
     let query_impl = ctx.query_method();
     let stream_impl = ctx.stream_filtered_method();
     let relation_impls = ctx.relation_methods();
@@ -137,6 +138,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #update_impl
             #delete_impl
             #list_impl
+            #list_after_impl
             #query_impl
             #stream_impl
             #lookup_impls

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -58,6 +58,71 @@ pub(super) fn tx_wrapping(streams: bool) -> (TokenStream, TokenStream, TokenStre
 }
 
 impl Context<'_> {
+    /// Generate the `list_after` keyset-pagination method.
+    ///
+    /// # SQL Pattern
+    ///
+    /// ```sql
+    /// SELECT cols FROM table [WHERE id < $1] [AND deleted_at IS NULL]
+    /// ORDER BY id DESC LIMIT $n
+    /// ```
+    pub fn list_after_method(&self) -> TokenStream {
+        let Self {
+            entity_name,
+            row_name,
+            table,
+            columns_str,
+            id_name,
+            id_type,
+            soft_delete,
+            ..
+        } = self;
+
+        let deleted_and = if *soft_delete {
+            " AND deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let deleted_where = if *soft_delete {
+            " WHERE deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let cursor_sql = format!(
+            "SELECT {columns_str} FROM {table} WHERE {id_name} < $1{deleted_and} \
+             ORDER BY {id_name} DESC LIMIT $2"
+        );
+        let head_sql = format!(
+            "SELECT {columns_str} FROM {table}{deleted_where} ORDER BY {id_name} DESC LIMIT $1"
+        );
+
+        let span = instrument(&entity_name.to_string(), "list_after");
+
+        quote! {
+            #span
+            async fn list_after(
+                &self,
+                cursor: Option<#id_type>,
+                limit: i64,
+            ) -> Result<Vec<#entity_name>, Self::Error> {
+                let rows: Vec<#row_name> = match cursor {
+                    Some(after) => {
+                        sqlx::query_as(#cursor_sql)
+                            .bind(&after)
+                            .bind(limit)
+                            .fetch_all(self).await?
+                    }
+                    None => {
+                        sqlx::query_as(#head_sql)
+                            .bind(limit)
+                            .fetch_all(self).await?
+                    }
+                };
+                Ok(rows.into_iter().map(#entity_name::from).collect())
+            }
+        }
+    }
+
     /// Generate the `create` method implementation.
     ///
     /// # SQL Pattern
@@ -450,5 +515,53 @@ impl Context<'_> {
                 Ok(rows.into_iter().map(#entity_name::from).collect())
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod list_after_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::super::context::Context;
+    use crate::entity::parse::EntityDef;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    #[test]
+    fn list_after_generates_keyset_sql() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "posts")]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub title: String,
+            }
+        });
+        let code = Context::new(&entity).list_after_method().to_string();
+        assert!(code.contains("id < $1"));
+        assert!(code.contains("ORDER BY id DESC LIMIT $2"));
+        assert!(code.contains("ORDER BY id DESC LIMIT $1"));
+    }
+
+    #[test]
+    fn list_after_respects_soft_delete() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "posts", soft_delete)]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub title: String,
+                pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+            }
+        });
+        let code = Context::new(&entity).list_after_method().to_string();
+        assert!(code.contains("AND deleted_at IS NULL"));
+        assert!(code.contains("WHERE deleted_at IS NULL"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/query.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/query.rs
@@ -69,8 +69,25 @@ impl Context<'_> {
     ///     Ok(rows.into_iter().map(User::from).collect())
     /// }
     /// ```
+    /// Expression yielding the runtime `ORDER BY` fragment.
+    ///
+    /// With `#[sort]` fields the fragment comes from the whitelisted
+    /// `{Entity}SortField::order_by`; otherwise the historical
+    /// `{id} DESC` default is kept.
+    fn order_by_expr(&self) -> TokenStream {
+        let id_name = self.id_name;
+        let default = format!("{id_name} DESC");
+        if self.entity.has_sort_fields() {
+            quote! {
+                query.sort.map(|s| s.order_by()).unwrap_or(#default)
+            }
+        } else {
+            quote! { #default }
+        }
+    }
+
     pub fn query_method(&self) -> TokenStream {
-        if !self.entity.has_filters() {
+        if !self.entity.has_filters() && !self.entity.has_sort_fields() {
             return TokenStream::new();
         }
 
@@ -79,7 +96,6 @@ impl Context<'_> {
             row_name,
             table,
             columns_str,
-            id_name,
             soft_delete,
             ..
         } = self;
@@ -89,6 +105,8 @@ impl Context<'_> {
 
         let where_conditions = generate_where_conditions(&filter_fields, *soft_delete);
         let bindings = generate_query_bindings(&filter_fields);
+
+        let order_by_expr = self.order_by_expr();
 
         quote! {
             async fn query(&self, query: #query_type) -> Result<Vec<#entity_name>, Self::Error> {
@@ -107,9 +125,10 @@ impl Context<'_> {
                 param_idx += 1;
                 let offset_idx = param_idx;
 
+                let __order_by = #order_by_expr;
                 let sql = format!(
-                    "SELECT {} FROM {} {} ORDER BY {} DESC LIMIT ${} OFFSET ${}",
-                    #columns_str, #table, where_clause, stringify!(#id_name), limit_idx, offset_idx
+                    "SELECT {} FROM {} {} ORDER BY {} LIMIT ${} OFFSET ${}",
+                    #columns_str, #table, where_clause, __order_by, limit_idx, offset_idx
                 );
 
                 let mut q = sqlx::query_as::<_, #row_name>(::sqlx::AssertSqlSafe(sql));
@@ -137,7 +156,6 @@ impl Context<'_> {
             row_name,
             table,
             columns_str,
-            id_name,
             soft_delete,
             ..
         } = self;
@@ -150,6 +168,8 @@ impl Context<'_> {
 
         // For now, generate a simple implementation that fetches all and converts to
         // stream True streaming would require more complex lifetime handling
+        let order_by_expr = self.order_by_expr();
+
         quote! {
             async fn stream_filtered(
                 &self,
@@ -174,9 +194,10 @@ impl Context<'_> {
                 param_idx += 1;
                 let offset_idx = param_idx;
 
+                let __order_by = #order_by_expr;
                 let sql = format!(
-                    "SELECT {} FROM {} {} ORDER BY {} DESC LIMIT ${} OFFSET ${}",
-                    #columns_str, #table, where_clause, stringify!(#id_name), limit_idx, offset_idx
+                    "SELECT {} FROM {} {} ORDER BY {} LIMIT ${} OFFSET ${}",
+                    #columns_str, #table, where_clause, __order_by, limit_idx, offset_idx
                 );
 
                 let mut q = sqlx::query_as::<_, #row_name>(::sqlx::AssertSqlSafe(sql));

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -469,7 +469,7 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(
     Entity,
     attributes(
-        entity, field, id, auto, owner, validate, belongs_to, has_many, projection, filter,
+        entity, field, id, auto, owner, sort, validate, belongs_to, has_many, projection, filter,
         command, example, column, map
     )
 )]

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.8" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.12", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.13", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/sort_keyset.rs
+++ b/crates/entity-derive/tests/cases/pass/sort_keyset.rs
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "posts")]
+pub struct Post {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[sort]
+    #[filter(like)]
+    pub title: String,
+
+    #[field(create, response)]
+    #[sort]
+    pub views: i64,
+}
+
+async fn exercise(pool: sqlx::PgPool, cursor: Option<Uuid>) -> Result<(), sqlx::Error> {
+    let query = PostQuery {
+        title: Some("%rust%".into()),
+        sort: Some(PostSortField::ViewsDesc),
+        limit: Some(20),
+        ..Default::default()
+    };
+    let _filtered: Vec<Post> = pool.query(query).await?;
+
+    let first_page: Vec<Post> = pool.list_after(None, 20).await?;
+    let _next_page: Vec<Post> = pool
+        .list_after(first_page.last().map(|p| p.id).or(cursor), 20)
+        .await?;
+    Ok(())
+}
+
+fn main() {
+    assert_eq!(PostSortField::TitleAsc.order_by(), "title ASC");
+    assert_eq!(PostSortField::ViewsDesc.order_by(), "views DESC");
+    let json = serde_json::to_string(&PostSortField::TitleAsc).unwrap();
+    assert_eq!(json, "\"title_asc\"");
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #147.

Adds whitelisted dynamic sorting and keyset pagination.

## `#[sort]`

- Marks sortable columns; generates `{Entity}SortField` — one `Asc`/`Desc` variant per column with `order_by() -> &'static str` returning a whitelisted fragment. User input can never inject SQL: unknown values fail deserialization (`snake_case` JSON representation, `ToSchema` under `api`).
- `{Entity}Query` gains `sort: Option<{Entity}SortField>`; `query()` (and `stream_filtered`) use it for `ORDER BY`, falling back to the historical `{id} DESC`.
- A sort-only entity (no `#[filter]`) now also gets the Query struct and `query()` method.

## `list_after` (keyset)

- `list_after(cursor: Option<IdT>, limit) -> Vec<Entity>` on every repository: `WHERE id < $1 ORDER BY id DESC LIMIT $2` (cursor-less head variant included), soft-delete aware, static SQL.
- With default UUIDv7 ids the walk is chronologically stable and does not degrade on deep pages the way OFFSET does.

## Testing

- 8 new unit tests (sort enum shape, whitelisted fragments, sort-only gating, keyset SQL incl. soft delete) — 647 total green
- trybuild pass case: query with sort + two-page keyset walk against `PgPool`, JSON round-trip of the sort selector
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: field quick-reference, "Sorting & Keyset Pagination" section, features table, pins 0.15
- entity-derive 0.14.0 → 0.15.0, entity-derive-impl 0.12.0 → 0.13.0
- Wiki (Filtering ×5) follows after merge