### PR TITLE
148

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.8" }
-entity-derive = { path = "crates/entity-derive", version = "0.15" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.13" }
+entity-derive = { path = "crates/entity-derive", version = "0.16" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.14" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.15", features = ["postgres", "api"] }
+entity-derive = { version = "0.16", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.15", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.16", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.15", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.16", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -132,6 +132,7 @@ tracing-subscriber = "0.3"
 | **`OpenAPI` Docs** | Auto-generated Swagger/OpenAPI documentation |
 | **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]` |
 | **Sorting & Keyset** | `#[sort]` whitelisted ORDER BY + `list_after` cursor pagination |
+| **Bulk Operations** | `find_by_ids`, atomic `create_many`, soft-delete-aware `delete_many` |
 | **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
@@ -312,6 +313,22 @@ Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
 
+### Bulk Operations
+
+Every repository ships batch primitives — one round-trip reads and
+atomic writes:
+
+```rust,ignore
+let posts: Vec<Post> = pool.find_by_ids(ids).await?;          // WHERE id = ANY($1)
+let created: Vec<Post> = pool.create_many(dtos).await?;       // one transaction
+let removed: u64 = pool.delete_many(stale_ids).await?;        // soft-delete aware
+```
+
+`create_many` rolls the whole batch back if any row fails; `delete_many`
+returns the number of rows actually affected. With `events` delivery
+(streams or outbox) per-row events are emitted inside the same
+transaction.
+
 ### Sorting & Keyset Pagination
 
 Mark sortable columns with `#[sort]` — the Query struct gains a
@@ -454,7 +471,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.15", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.16", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.13.0"
+version = "0.14.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -91,6 +91,19 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         quote! { async fn create(&self, dto: #create_dto) -> Result<#entity_name, Self::Error>; }
     };
 
+    let create_many_method = if entity.create_fields().is_empty() {
+        TokenStream::new()
+    } else {
+        quote! {
+            /// Insert a batch of entities atomically.
+            ///
+            /// All rows are inserted inside one transaction: a failing
+            /// row rolls back the whole batch. Per-row events are
+            /// emitted when events delivery is enabled.
+            async fn create_many(&self, dtos: Vec<#create_dto>) -> Result<Vec<#entity_name>, Self::Error>;
+        }
+    };
+
     let update_method = if entity.update_fields().is_empty() {
         TokenStream::new()
     } else {
@@ -140,6 +153,21 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             async fn delete(&self, id: #id_type) -> Result<bool, Self::Error>;
 
             async fn list(&self, limit: i64, offset: i64) -> Result<Vec<#entity_name>, Self::Error>;
+
+            /// Fetch all entities whose ids are in the given list.
+            ///
+            /// Uses `WHERE id = ANY($1)`; missing ids are silently absent
+            /// from the result. Soft-deleted rows are filtered out.
+            async fn find_by_ids(&self, ids: Vec<#id_type>) -> Result<Vec<#entity_name>, Self::Error>;
+
+            #create_many_method
+
+            /// Delete all entities whose ids are in the given list.
+            ///
+            /// Returns the number of rows actually deleted. Soft-delete
+            /// aware; per-row events are emitted when events delivery is
+            /// enabled.
+            async fn delete_many(&self, ids: Vec<#id_type>) -> Result<u64, Self::Error>;
 
             /// List entities after the given cursor (keyset pagination).
             ///

--- a/crates/entity-derive-impl/src/entity/sql/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres.rs
@@ -60,6 +60,7 @@
 //!
 //! Generated code is gated behind `#[cfg(feature = "postgres")]`.
 
+mod bulk;
 mod context;
 mod crud;
 mod lookup;
@@ -110,6 +111,9 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     let delete_impl = ctx.delete_method();
     let list_impl = ctx.list_method();
     let list_after_impl = ctx.list_after_method();
+    let find_by_ids_impl = ctx.find_by_ids_method();
+    let create_many_impl = ctx.create_many_method();
+    let delete_many_impl = ctx.delete_many_method();
     let query_impl = ctx.query_method();
     let stream_impl = ctx.stream_filtered_method();
     let relation_impls = ctx.relation_methods();
@@ -139,6 +143,9 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #delete_impl
             #list_impl
             #list_after_impl
+            #find_by_ids_impl
+            #create_many_impl
+            #delete_many_impl
             #query_impl
             #stream_impl
             #lookup_impls

--- a/crates/entity-derive-impl/src/entity/sql/postgres/bulk.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/bulk.rs
@@ -1,0 +1,293 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Bulk operation generators for `PostgreSQL`.
+//!
+//! | Method | SQL |
+//! |--------|-----|
+//! | `find_by_ids` | `SELECT ... WHERE id = ANY($1)` |
+//! | `create_many` | per-row `INSERT ... RETURNING` inside one transaction |
+//! | `delete_many` | `DELETE`/soft-`UPDATE` with `id = ANY($1) RETURNING id` |
+//!
+//! All bulk writes are atomic: a failing row rolls back the whole
+//! batch. Events, NOTIFY and the transactional outbox are emitted per
+//! affected row, matching the single-row methods.
+
+use proc_macro2::TokenStream;
+use quote::quote;
+
+use super::{context::Context, crud::tx_wrapping, helpers::insert_bindings};
+use crate::{entity::parse::ReturningMode, utils::tracing::instrument};
+
+impl Context<'_> {
+    /// Generate the `find_by_ids` method implementation.
+    pub fn find_by_ids_method(&self) -> TokenStream {
+        let Self {
+            entity_name,
+            row_name,
+            table,
+            columns_str,
+            id_name,
+            id_type,
+            soft_delete,
+            ..
+        } = self;
+
+        let deleted_filter = if *soft_delete {
+            " AND deleted_at IS NULL"
+        } else {
+            ""
+        };
+        let sql =
+            format!("SELECT {columns_str} FROM {table} WHERE {id_name} = ANY($1){deleted_filter}");
+        let span = instrument(&entity_name.to_string(), "find_by_ids");
+
+        quote! {
+            #span
+            async fn find_by_ids(&self, ids: Vec<#id_type>) -> Result<Vec<#entity_name>, Self::Error> {
+                let rows: Vec<#row_name> = sqlx::query_as(#sql)
+                    .bind(&ids)
+                    .fetch_all(self).await?;
+                Ok(rows.into_iter().map(#entity_name::from).collect())
+            }
+        }
+    }
+
+    /// Generate the `create_many` method implementation.
+    ///
+    /// # Returns
+    ///
+    /// Empty `TokenStream` if entity has no create fields.
+    pub fn create_many_method(&self) -> TokenStream {
+        if self.entity.create_fields().is_empty() {
+            return TokenStream::new();
+        }
+
+        let Self {
+            entity_name,
+            row_name,
+            insertable_name,
+            create_dto,
+            table,
+            columns_str,
+            placeholders_str,
+            entity,
+            returning,
+            ..
+        } = self;
+
+        let bindings = insert_bindings(entity.all_fields());
+        let span = instrument(&entity_name.to_string(), "create_many");
+        let outbox_created = self.outbox_created();
+        let notify = self.notify_created();
+
+        let insert_row = if matches!(returning, ReturningMode::Full) {
+            quote! {
+                let row: #row_name = sqlx::query_as(
+                    concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ") RETURNING *")
+                )
+                    #(#bindings)*
+                    .fetch_one(&mut *tx).await?;
+                let entity = #entity_name::from(row);
+            }
+        } else {
+            quote! {
+                sqlx::query(concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ")"))
+                    #(#bindings)*
+                    .execute(&mut *tx).await?;
+            }
+        };
+
+        quote! {
+            #span
+            async fn create_many(
+                &self,
+                dtos: Vec<#create_dto>,
+            ) -> Result<Vec<#entity_name>, Self::Error> {
+                let mut tx = self.begin().await?;
+                let mut created = Vec::with_capacity(dtos.len());
+                for dto in dtos {
+                    let entity = #entity_name::from(dto);
+                    let insertable = #insertable_name::from(&entity);
+                    #insert_row
+                    #outbox_created
+                    #notify
+                    created.push(entity);
+                }
+                tx.commit().await?;
+                Ok(created)
+            }
+        }
+    }
+
+    /// Generate the `delete_many` method implementation.
+    ///
+    /// Soft-delete aware; per-row delete events are emitted inside the
+    /// same transaction when events delivery is enabled.
+    pub fn delete_many_method(&self) -> TokenStream {
+        let Self {
+            entity_name,
+            table,
+            id_name,
+            id_type,
+            soft_delete,
+            streams,
+            ..
+        } = self;
+
+        let sql = if *soft_delete {
+            format!(
+                "UPDATE {table} SET deleted_at = NOW() \
+                 WHERE {id_name} = ANY($1) AND deleted_at IS NULL RETURNING {id_name}"
+            )
+        } else {
+            format!("DELETE FROM {table} WHERE {id_name} = ANY($1) RETURNING {id_name}")
+        };
+        let span = instrument(&entity_name.to_string(), "delete_many");
+
+        let emit_events = *streams || self.outbox;
+        if !emit_events {
+            return quote! {
+                #span
+                async fn delete_many(&self, ids: Vec<#id_type>) -> Result<u64, Self::Error> {
+                    let deleted: Vec<#id_type> = sqlx::query_scalar(#sql)
+                        .bind(&ids)
+                        .fetch_all(self).await?;
+                    Ok(deleted.len() as u64)
+                }
+            };
+        }
+
+        let (tx_open, tx_close, _executor) = tx_wrapping(true);
+        let outbox_deleted = self.outbox_deleted();
+        let notify = if *soft_delete {
+            self.notify_soft_deleted()
+        } else {
+            self.notify_hard_deleted()
+        };
+
+        quote! {
+            #span
+            async fn delete_many(&self, ids: Vec<#id_type>) -> Result<u64, Self::Error> {
+                #tx_open
+                let deleted: Vec<#id_type> = sqlx::query_scalar(#sql)
+                    .bind(&ids)
+                    .fetch_all(&mut *tx).await?;
+                let count = deleted.len() as u64;
+                for id in deleted {
+                    #outbox_deleted
+                    #notify
+                }
+                #tx_close
+                Ok(count)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::super::context::Context;
+    use crate::entity::parse::EntityDef;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    fn post_entity(extra: proc_macro2::TokenStream) -> EntityDef {
+        parse_entity(quote! {
+            #[entity(table = "posts" #extra)]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub title: String,
+            }
+        })
+    }
+
+    #[test]
+    fn find_by_ids_uses_any() {
+        let entity = post_entity(quote!());
+        let code = Context::new(&entity).find_by_ids_method().to_string();
+        assert!(code.contains("id = ANY($1)"));
+    }
+
+    #[test]
+    fn find_by_ids_respects_soft_delete() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "posts", soft_delete)]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub title: String,
+                pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+            }
+        });
+        let code = Context::new(&entity).find_by_ids_method().to_string();
+        assert!(code.contains("AND deleted_at IS NULL"));
+    }
+
+    #[test]
+    fn create_many_wraps_in_transaction() {
+        let entity = post_entity(quote!());
+        let code = Context::new(&entity).create_many_method().to_string();
+        assert!(code.contains("self . begin ()"));
+        assert!(code.contains("RETURNING *"));
+        assert!(code.contains("tx . commit ()"));
+    }
+
+    #[test]
+    fn create_many_absent_without_create_fields() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "counters")]
+            pub struct Counter {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(response)]
+                #[auto]
+                pub value: i64,
+            }
+        });
+        assert!(Context::new(&entity).create_many_method().is_empty());
+    }
+
+    #[test]
+    fn delete_many_plain_counts_without_transaction() {
+        let entity = post_entity(quote!());
+        let code = Context::new(&entity).delete_many_method().to_string();
+        assert!(code.contains("DELETE FROM posts WHERE id = ANY($1) RETURNING id"));
+        assert!(!code.contains("begin"));
+    }
+
+    #[test]
+    fn delete_many_soft_delete_updates() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "posts", soft_delete)]
+            pub struct Post {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub title: String,
+                pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+            }
+        });
+        let code = Context::new(&entity).delete_many_method().to_string();
+        assert!(code.contains("SET deleted_at = NOW()"));
+        assert!(code.contains("AND deleted_at IS NULL RETURNING id"));
+    }
+
+    #[test]
+    fn delete_many_with_outbox_emits_per_row() {
+        let entity = post_entity(quote!(, events(outbox)));
+        let code = Context::new(&entity).delete_many_method().to_string();
+        assert!(code.contains("begin"));
+        assert!(code.contains("for id in deleted"));
+        assert!(code.contains("entity_outbox"));
+    }
+}

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.8" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.13", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.14", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/bulk_ops.rs
+++ b/crates/entity-derive/tests/cases/pass/bulk_ops.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "posts")]
+pub struct Post {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub title: String,
+}
+
+async fn exercise(pool: sqlx::PgPool, ids: Vec<Uuid>) -> Result<(), sqlx::Error> {
+    let created: Vec<Post> = pool
+        .create_many(vec![
+            CreatePostRequest {
+                title: "a".into(),
+            },
+            CreatePostRequest {
+                title: "b".into(),
+            },
+        ])
+        .await?;
+    let found: Vec<Post> = pool.find_by_ids(created.iter().map(|p| p.id).collect()).await?;
+    let removed: u64 = pool.delete_many(ids).await?;
+    let _ = (found, removed);
+    Ok(())
+}
+
+fn main() {
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #148.

Adds batch primitives to every generated repository.

## Methods

- `find_by_ids(ids) -> Vec<Entity>` — `WHERE id = ANY($1)`, soft-delete filtered, single round-trip; missing ids silently absent
- `create_many(dtos) -> Vec<Entity>` — per-row `INSERT ... RETURNING` inside one transaction; a failing row rolls back the whole batch; honors the `returning` mode
- `delete_many(ids) -> u64` — `DELETE`/soft-`UPDATE` with `id = ANY($1) RETURNING id`, returns the actually-affected count

## Events semantics

With streams or the transactional outbox enabled, per-row events (Created / SoftDeleted / HardDeleted) are emitted inside the same transaction, reusing the single-row fragments; without events delivery the plain paths stay transaction-free single statements.

## Testing

- 8 new unit tests (ANY-SQL, soft delete, transaction wrapping, returning modes, per-row outbox emission, gating without create fields) — 654 total green
- trybuild pass case exercising all three methods against `PgPool`
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: new "Bulk Operations" section + features table, pins 0.16
- entity-derive 0.15.0 → 0.16.0, entity-derive-impl 0.13.0 → 0.14.0
- Wiki follows after merge