### PR TITLE
149

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ license = "MIT"
 repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
-entity-core = { path = "crates/entity-core", version = "0.8" }
-entity-derive = { path = "crates/entity-derive", version = "0.16" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.14" }
+entity-core = { path = "crates/entity-core", version = "0.9" }
+entity-derive = { path = "crates/entity-derive", version = "0.17" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.15" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.16", features = ["postgres", "api"] }
+entity-derive = { version = "0.17", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.16", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.17", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.16", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.17", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -133,6 +133,7 @@ tracing-subscriber = "0.3"
 | **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]` |
 | **Sorting & Keyset** | `#[sort]` whitelisted ORDER BY + `list_after` cursor pagination |
 | **Bulk Operations** | `find_by_ids`, atomic `create_many`, soft-delete-aware `delete_many` |
+| **PATCH Semantics** | Dynamic UPDATE SET; double-`Option` distinguishes "leave" from "set NULL" |
 | **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
@@ -313,6 +314,24 @@ Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
 
+### PATCH Semantics
+
+Update DTOs are true partial patches. Fields absent from the payload are
+left untouched — the generated UPDATE only includes columns actually
+present. Nullable columns use double-`Option`, so "leave unchanged" and
+"set NULL" are finally distinguishable:
+
+```rust,ignore
+// {}                          → nothing changes (fetch-and-return)
+// {"nickname": null}          → nickname = NULL
+// {"nickname": "neo"}         → nickname = 'neo'
+let patch: UpdateProfileRequest = serde_json::from_str(body)?;
+let profile = pool.update(id, patch).await?;
+```
+
+In Rust code: `None` = leave, `Some(None)` = SET NULL,
+`Some(Some(v))` = SET v.
+
 ### Bulk Operations
 
 Every repository ships batch primitives — one round-trip reads and
@@ -471,7 +490,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.16", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.17", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -413,3 +413,96 @@ mod tests {
         assert_eq!((OK, MISMATCH), (true, false));
     }
 }
+
+/// Serde helpers for generated DTOs.
+#[cfg(feature = "serde")]
+pub mod serde_helpers {
+    /// Double-`Option` (de)serialization for PATCH semantics.
+    ///
+    /// | JSON | Rust |
+    /// |------|------|
+    /// | field absent | `None` (leave unchanged) |
+    /// | `"field": null` | `Some(None)` (set column to NULL) |
+    /// | `"field": v` | `Some(Some(v))` (set column to v) |
+    pub mod double_option {
+        use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+        /// Deserialize a present-but-maybe-null field into `Some(inner)`.
+        ///
+        /// # Errors
+        ///
+        /// Propagates inner deserialization errors.
+        pub fn deserialize<'de, T, D>(deserializer: D) -> Result<Option<Option<T>>, D::Error>
+        where
+            T: Deserialize<'de>,
+            D: Deserializer<'de>
+        {
+            Option::<T>::deserialize(deserializer).map(Some)
+        }
+
+        /// Serialize the inner `Option`, treating outer `None` as null.
+        ///
+        /// # Errors
+        ///
+        /// Propagates inner serialization errors.
+        pub fn serialize<T, S>(value: &Option<Option<T>>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            T: Serialize,
+            S: Serializer
+        {
+            match value {
+                Some(inner) => inner.serialize(serializer),
+                None => serializer.serialize_none()
+            }
+        }
+    }
+
+    #[cfg(all(test, feature = "serde_json"))]
+    mod tests {
+        #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Default)]
+        struct Patch {
+            #[serde(
+                default,
+                skip_serializing_if = "Option::is_none",
+                with = "super::double_option"
+            )]
+            nick: Option<Option<String>>
+        }
+
+        #[test]
+        fn absent_field_is_outer_none() {
+            let patch: Patch = serde_json::from_str("{}").unwrap();
+            assert_eq!(patch.nick, None);
+        }
+
+        #[test]
+        fn null_field_is_some_none() {
+            let patch: Patch = serde_json::from_str(r#"{"nick": null}"#).unwrap();
+            assert_eq!(patch.nick, Some(None));
+        }
+
+        #[test]
+        fn value_field_is_some_some() {
+            let patch: Patch = serde_json::from_str(r#"{"nick": "neo"}"#).unwrap();
+            assert_eq!(patch.nick, Some(Some("neo".to_string())));
+        }
+
+        #[test]
+        fn outer_none_skipped_on_serialize() {
+            let json = serde_json::to_string(&Patch {
+                nick: None
+            })
+            .unwrap();
+            assert_eq!(json, "{}");
+        }
+
+        #[test]
+        fn some_none_serializes_null() {
+            let json = serde_json::to_string(&Patch {
+                nick: Some(None)
+            })
+            .unwrap();
+            assert_eq!(json, r#"{"nick":null}"#);
+        }
+    }
+}

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.14.0"
+version = "0.15.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/dto.rs
+++ b/crates/entity-derive-impl/src/entity/dto.rs
@@ -91,7 +91,14 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
         let n = f.name();
         let t = f.ty();
         if f.is_option() {
-            quote! { pub #n: #t }
+            quote! {
+                #[serde(
+                    default,
+                    skip_serializing_if = "Option::is_none",
+                    with = "::entity_core::serde_helpers::double_option"
+                )]
+                pub #n: Option<#t>
+            }
         } else {
             quote! { pub #n: Option<#t> }
         }

--- a/crates/entity-derive-impl/src/entity/parse/dialect.rs
+++ b/crates/entity-derive-impl/src/entity/parse/dialect.rs
@@ -72,20 +72,6 @@ impl DatabaseDialect {
             .join(", ")
     }
 
-    /// Generate SET clause for UPDATE statement.
-    #[must_use]
-    pub fn set_clause(&self, fields: &[&str]) -> String {
-        match self {
-            Self::Postgres | Self::ClickHouse => fields
-                .iter()
-                .enumerate()
-                .map(|(i, f)| format!("{} = ${}", f, i + 1))
-                .collect::<Vec<_>>()
-                .join(", "),
-            Self::MongoDB => fields.join(", ") // MongoDB uses $set operator
-        }
-    }
-
     /// Get the feature flag name for this dialect.
     #[must_use]
     pub const fn feature_flag(&self) -> &'static str {
@@ -133,27 +119,6 @@ mod tests {
         let d = DatabaseDialect::MongoDB;
         assert_eq!(d.placeholder(1), "$1");
         assert_eq!(d.placeholders(3), "$1, $2, $3");
-    }
-
-    #[test]
-    fn set_clause_postgres() {
-        let d = DatabaseDialect::Postgres;
-        let fields = ["name", "email"];
-        assert_eq!(d.set_clause(&fields), "name = $1, email = $2");
-    }
-
-    #[test]
-    fn set_clause_clickhouse() {
-        let d = DatabaseDialect::ClickHouse;
-        let fields = ["name", "email"];
-        assert_eq!(d.set_clause(&fields), "name = $1, email = $2");
-    }
-
-    #[test]
-    fn set_clause_mongodb() {
-        let d = DatabaseDialect::MongoDB;
-        let fields = ["name", "email"];
-        assert_eq!(d.set_clause(&fields), "name, email");
     }
 
     #[test]

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -28,10 +28,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{
-    context::Context,
-    helpers::{insert_bindings, update_bindings}
-};
+use super::{context::Context, helpers::insert_bindings};
 use crate::{entity::parse::ReturningMode, utils::tracing::instrument};
 
 /// Return the `(open, close, executor)` token fragments that bracket
@@ -318,11 +315,9 @@ impl Context<'_> {
             ..
         } = self;
 
-        let field_names: Vec<String> = update_fields.iter().map(|f| f.name_str()).collect();
-        let field_refs: Vec<&str> = field_names.iter().map(String::as_str).collect();
-        let set_clause = dialect.set_clause(&field_refs);
-        let where_placeholder = dialect.placeholder(update_fields.len() + 1);
-        let bindings = update_bindings(&update_fields);
+        let set_stmts = super::helpers::dynamic_set_stmts(&update_fields);
+        let set_binds = super::helpers::dynamic_set_binds(&update_fields);
+        let _ = dialect;
 
         let span = instrument(&entity_name.to_string(), "update");
 
@@ -338,14 +333,18 @@ impl Context<'_> {
             return quote! {
                 #span
                 async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
+                    #set_stmts
+                    if __sets.is_empty() {
+                        return <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound.into());
+                    }
                     let mut tx = self.begin().await?;
                     #fetch_old
-                    let row: #row_name = sqlx::query_as(
-                        ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder))
-                    )
-                        #(#bindings)*
-                        .bind(&id)
-                        .fetch_one(&mut *tx).await?;
+                    let mut q = sqlx::query_as::<_, #row_name>(
+                        ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING *", #table, __sets.join(", "), stringify!(#id_name), __idx))
+                    );
+                    #set_binds
+                    q = q.bind(&id);
+                    let row: #row_name = q.fetch_one(&mut *tx).await?;
                     let entity = #entity_name::from(row);
                     #outbox_updated
                     #notify
@@ -363,12 +362,16 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        let row: #row_name = sqlx::query_as(
-                            ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING *", #table, #set_clause, stringify!(#id_name), #where_placeholder))
-                        )
-                            #(#bindings)*
-                            .bind(&id)
-                            .fetch_one(self).await?;
+                        #set_stmts
+                        if __sets.is_empty() {
+                            return <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound.into());
+                        }
+                        let mut q = sqlx::query_as::<_, #row_name>(
+                            ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING *", #table, __sets.join(", "), stringify!(#id_name), __idx))
+                        );
+                        #set_binds
+                        q = q.bind(&id);
+                        let row: #row_name = q.fetch_one(self).await?;
                         Ok(#entity_name::from(row))
                     }
                 }
@@ -377,10 +380,13 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {}", #table, #set_clause, stringify!(#id_name), #where_placeholder)))
-                            #(#bindings)*
-                            .bind(&id)
-                            .execute(self).await?;
+                        #set_stmts
+                        if !__sets.is_empty() {
+                            let mut q = sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}", #table, __sets.join(", "), stringify!(#id_name), __idx)));
+                            #set_binds
+                            q = q.bind(&id);
+                            q.execute(self).await?;
+                        }
                         <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)
                     }
                 }
@@ -390,10 +396,13 @@ impl Context<'_> {
                 quote! {
                     #span
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
-                        sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING {}", #table, #set_clause, stringify!(#id_name), #where_placeholder, #returning_cols)))
-                            #(#bindings)*
-                            .bind(&id)
-                            .execute(self).await?;
+                        #set_stmts
+                        if !__sets.is_empty() {
+                            let mut q = sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING {}", #table, __sets.join(", "), stringify!(#id_name), __idx, #returning_cols)));
+                            #set_binds
+                            q = q.bind(&id);
+                            q.execute(self).await?;
+                        }
                         <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)
                     }
                 }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -8,7 +8,7 @@
 //!
 //! - [`join_columns`] — builds column list for SELECT/INSERT
 //! - [`insert_bindings`] — builds `.bind()` chain for INSERT
-//! - [`update_bindings`] — builds `.bind()` chain for UPDATE
+//! - [`dynamic_set_stmts`] / [`dynamic_set_binds`] — dynamic UPDATE SET builder
 //! - [`generate_where_conditions`] — builds WHERE clause for query method
 //! - [`generate_query_bindings`] — builds parameter bindings for query method
 
@@ -47,24 +47,6 @@ pub fn insert_bindings(fields: &[FieldDef]) -> Vec<TokenStream> {
         .map(|f| {
             let name = f.name();
             quote! { .bind(insertable.#name) }
-        })
-        .collect()
-}
-
-/// Build `.bind(dto.field)` chain for UPDATE.
-///
-/// # Generated Code
-///
-/// ```rust,ignore
-/// .bind(dto.name)
-/// .bind(dto.email)
-/// ```
-pub fn update_bindings(fields: &[&FieldDef]) -> Vec<TokenStream> {
-    fields
-        .iter()
-        .map(|f| {
-            let name = f.name();
-            quote! { .bind(dto.#name) }
         })
         .collect()
 }
@@ -210,6 +192,75 @@ pub fn generate_query_bindings(fields: &[&FieldDef]) -> TokenStream {
     quote! { #(#bindings)* }
 }
 
+/// Generate runtime statements building a dynamic UPDATE SET clause.
+///
+/// Emits `__sets: Vec<String>` and `__idx: usize` bindings. Fields
+/// absent from the DTO are skipped entirely; nullable fields use
+/// double-`Option` semantics where `Some(None)` renders `col = NULL`.
+pub fn dynamic_set_stmts(fields: &[&FieldDef]) -> TokenStream {
+    let per_field: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let name = f.name();
+            let column = f.name_str();
+            let assignment = format!("{column} = ${{}}");
+            let null_assignment = format!("{column} = NULL");
+            if f.is_option() {
+                quote! {
+                    match &dto.#name {
+                        None => {}
+                        Some(None) => __sets.push(#null_assignment.to_string()),
+                        Some(Some(_)) => {
+                            __sets.push(format!(#assignment, __idx));
+                            __idx += 1;
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    if dto.#name.is_some() {
+                        __sets.push(format!(#assignment, __idx));
+                        __idx += 1;
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        let mut __sets: Vec<String> = Vec::new();
+        let mut __idx: usize = 1;
+        #(#per_field)*
+    }
+}
+
+/// Generate conditional `.bind()` statements matching [`dynamic_set_stmts`].
+///
+/// The query variable is expected to be named `q`.
+pub fn dynamic_set_binds(fields: &[&FieldDef]) -> TokenStream {
+    let per_field: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let name = f.name();
+            if f.is_option() {
+                quote! {
+                    if let Some(Some(__v)) = dto.#name {
+                        q = q.bind(__v);
+                    }
+                }
+            } else {
+                quote! {
+                    if let Some(__v) = dto.#name {
+                        q = q.bind(__v);
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! { #(#per_field)* }
+}
+
 #[cfg(test)]
 mod tests {
     use syn::{Field, parse_quote};
@@ -277,28 +328,6 @@ mod tests {
     #[test]
     fn insert_bindings_empty() {
         let bindings = insert_bindings(&[]);
-        assert!(bindings.is_empty());
-    }
-
-    #[test]
-    fn update_bindings_generates_bind_calls() {
-        let fields = [
-            parse_field(quote! { pub name: String }),
-            parse_field(quote! { pub email: String })
-        ];
-        let refs: Vec<&FieldDef> = fields.iter().collect();
-        let bindings = update_bindings(&refs);
-        assert_eq!(bindings.len(), 2);
-
-        let first = bindings[0].to_string();
-        assert!(first.contains("bind"), "Expected 'bind' in: {}", first);
-        assert!(first.contains("dto"), "Expected 'dto' in: {}", first);
-        assert!(first.contains("name"), "Expected 'name' in: {}", first);
-    }
-
-    #[test]
-    fn update_bindings_empty() {
-        let bindings = update_bindings(&[]);
         assert!(bindings.is_empty());
     }
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
@@ -20,7 +20,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{context::Context, helpers::update_bindings};
+use super::context::Context;
 use crate::utils::tracing::instrument;
 
 impl Context<'_> {
@@ -148,18 +148,10 @@ impl Context<'_> {
         let owner_name = owner.name();
         let owner_type = owner.ty();
 
-        let field_names: Vec<String> = update_fields.iter().map(|f| f.name_str()).collect();
-        let field_refs: Vec<&str> = field_names.iter().map(String::as_str).collect();
-        let set_clause = dialect.set_clause(&field_refs);
-        let id_placeholder = update_fields.len() + 1;
-        let owner_placeholder = update_fields.len() + 2;
-        let bindings = update_bindings(&update_fields);
-
-        let sql = format!(
-            "UPDATE {table} SET {set_clause} WHERE {id_name} = ${id_placeholder} \
-             AND {owner_col} = ${owner_placeholder} RETURNING *",
-            id_name = id_name
-        );
+        let set_stmts = super::helpers::dynamic_set_stmts(&update_fields);
+        let set_binds = super::helpers::dynamic_set_binds(&update_fields);
+        let _ = dialect;
+        let owner_col_str = owner_col.to_string();
 
         let span = instrument(&entity_name.to_string(), "update_scoped");
 
@@ -171,11 +163,18 @@ impl Context<'_> {
                 #owner_name: #owner_type,
                 dto: #update_dto,
             ) -> Result<Option<#entity_name>, Self::Error> {
-                let row: Option<#row_name> = sqlx::query_as(#sql)
-                    #(#bindings)*
-                    .bind(&id)
-                    .bind(&#owner_name)
-                    .fetch_optional(self).await?;
+                #set_stmts
+                if __sets.is_empty() {
+                    return self.find_by_id_scoped(id, #owner_name).await;
+                }
+                let mut q = sqlx::query_as::<_, #row_name>(::sqlx::AssertSqlSafe(format!(
+                    "UPDATE {} SET {} WHERE {} = ${} AND {} = ${} RETURNING *",
+                    #table, __sets.join(", "), stringify!(#id_name), __idx, #owner_col_str, __idx + 1
+                )));
+                #set_binds
+                q = q.bind(&id);
+                q = q.bind(&#owner_name);
+                let row: Option<#row_name> = q.fetch_optional(self).await?;
                 Ok(row.map(#entity_name::from))
             }
         }
@@ -243,10 +242,12 @@ mod tests {
     }
 
     #[test]
-    fn update_scoped_places_owner_after_id() {
+    fn update_scoped_builds_dynamic_set() {
         let entity = owned_entity(quote!());
         let code = Context::new(&entity).scoped_methods().to_string();
-        assert!(code.contains("id = $2 AND user_id = $3 RETURNING *"));
+        assert!(code.contains("__sets"));
+        assert!(code.contains("\"user_id\""));
+        assert!(code.contains("find_by_id_scoped (id , user_id)"));
     }
 }
 

--- a/crates/entity-derive-impl/src/entity/transaction.rs
+++ b/crates/entity-derive-impl/src/entity/transaction.rs
@@ -109,27 +109,31 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
         TokenStream::new()
     } else {
         let update_fields = entity.update_fields();
-        let field_names: Vec<String> = update_fields.iter().map(|f| f.name_str()).collect();
-        let field_refs: Vec<&str> = field_names.iter().map(String::as_str).collect();
-        let set_clause = ctx.dialect.set_clause(&field_refs);
-        let where_placeholder = ctx.dialect.placeholder(update_fields.len() + 1);
-        let update_bindings = super::sql::postgres::helpers::update_bindings(&update_fields);
+        let set_stmts = super::sql::postgres::helpers::dynamic_set_stmts(&update_fields);
+        let set_binds = super::sql::postgres::helpers::dynamic_set_binds(&update_fields);
 
         quote! {
             /// Update an entity within the transaction.
+            ///
+            /// Fields absent from the DTO stay unchanged; nullable fields
+            /// use double-`Option` semantics (`Some(None)` sets NULL).
             #update_span
             pub async fn update(
                 &mut self,
                 id: #id_type,
                 dto: #update_dto
             ) -> Result<#entity_name, sqlx::Error> {
-                let row: #row_name = sqlx::query_as(
-                    ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = {} RETURNING *",
-                        #table, #set_clause, stringify!(#id_name), #where_placeholder))
-                )
-                    #(#update_bindings)*
-                    .bind(&id)
-                    .fetch_one(&mut **self.tx).await?;
+                #set_stmts
+                if __sets.is_empty() {
+                    return self.find_by_id(id).await?.ok_or(sqlx::Error::RowNotFound);
+                }
+                let mut q = sqlx::query_as::<_, #row_name>(
+                    ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING *",
+                        #table, __sets.join(", "), stringify!(#id_name), __idx))
+                );
+                #set_binds
+                q = q.bind(&id);
+                let row: #row_name = q.fetch_one(&mut **self.tx).await?;
                 Ok(#entity_name::from(row))
             }
         }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -74,8 +74,8 @@ projections = ["entity-derive-impl/projections"]
 tracing = ["entity-core/tracing"]
 
 [dependencies]
-entity-core = { path = "../entity-core", version = "0.8" }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.14", default-features = false }
+entity-core = { path = "../entity-core", version = "0.9", features = ["serde"] }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.15", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/patch_double_option.rs
+++ b/crates/entity-derive/tests/cases/pass/patch_double_option.rs
@@ -1,0 +1,47 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "profiles")]
+pub struct Profile {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub name: String,
+
+    #[field(create, update, response)]
+    pub nickname: Option<String>,
+}
+
+async fn exercise(pool: sqlx::PgPool, id: Uuid) -> Result<(), sqlx::Error> {
+    let patch: UpdateProfileRequest = serde_json::from_str(r#"{"nickname": null}"#).unwrap();
+    let _updated: Profile = pool.update(id, patch).await?;
+    Ok(())
+}
+
+fn main() {
+    let absent: UpdateProfileRequest = serde_json::from_str("{}").unwrap();
+    assert_eq!(absent.name, None);
+    assert_eq!(absent.nickname, None);
+
+    let null_nick: UpdateProfileRequest = serde_json::from_str(r#"{"nickname": null}"#).unwrap();
+    assert_eq!(null_nick.nickname, Some(None));
+
+    let set_nick: UpdateProfileRequest =
+        serde_json::from_str(r#"{"nickname": "neo", "name": "Thomas"}"#).unwrap();
+    assert_eq!(set_nick.nickname, Some(Some("neo".to_string())));
+    assert_eq!(set_nick.name, Some("Thomas".to_string()));
+
+    let json = serde_json::to_string(&UpdateProfileRequest {
+        name: None,
+        nickname: Some(None),
+    })
+    .unwrap();
+    assert_eq!(json, r#"{"name":null,"nickname":null}"#);
+
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #149.

Makes generated updates true partial patches and fixes a latent hazard: the previous UPDATE wrote **every** update column positionally, so omitted fields were overwritten with NULL.

## Dynamic SET

- `update`, `update_scoped` and the transaction adapter's `update` now build the SET clause at runtime from the fields actually present in the DTO; omitted fields stay untouched
- An empty patch performs no write and returns the current row (`None`-safe in the scoped variant)
- Column names come from the macro, values are bound — no injection surface

## Double-`Option` for nullable fields

- Nullable entity fields become `Option<Option<T>>` in the Update DTO with a new `entity_core::serde_helpers::double_option` (de)serializer: absent → leave, `null` → SET NULL, value → SET value
- Facade enables entity-core's `serde` feature; serialization skips absent fields

## Breaking

- Update DTO shape changes for nullable fields (`Option<T>` → `Option<Option<T>>`) — minor version bump; JSON wire format is backward compatible (same payloads, better semantics)
- Internal `set_clause`/`update_bindings` helpers removed

## Testing

- 5 serde-helper unit tests (absent/null/value round-trips) + updated generator tests — 649 impl + 55 core green
- trybuild pass case: JSON round-trips of all three states + generated update compiles against `PgPool`
- clippy `--all-targets -D warnings` clean, all-features suite green, examples build, deny ok

## Docs & versions

- README: new "PATCH Semantics" section + features table, pins 0.17
- entity-core 0.8.0 → 0.9.0, entity-derive-impl 0.14.0 → 0.15.0, entity-derive 0.16.0 → 0.17.0
- Wiki follows after merge