### PR TITLE
150

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.9" }
-entity-derive = { path = "crates/entity-derive", version = "0.17" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.15" }
+entity-derive = { path = "crates/entity-derive", version = "0.18" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.16" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.17", features = ["postgres", "api"] }
+entity-derive = { version = "0.18", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.17", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.18", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.17", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.18", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -181,6 +181,11 @@ tracing-subscriber = "0.3"
     dialect = "postgres",      // Optional: database dialect
     aggregate_root,            // Optional: New{T} DTOs + transactional save
     soft_delete,               // Optional: use deleted_at instead of DELETE
+    migrations(                // Optional: extra DDL alongside the table
+        touch_updated_at,      // updated_at trigger (shared function)
+        audit,                 // JSONB audit-log table + trigger
+        extensions = "pg_trgm",// CREATE EXTENSION statements
+    ),
     upsert(                    // Optional: INSERT ... ON CONFLICT method
         conflict = "email",    // #[column(unique)] field(s) or unique_index columns
         action = "update",     // "update" (default) or "nothing"
@@ -313,6 +318,26 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Migration Triggers & Extensions
+
+`migrations(...)` options emit the DDL production tables actually carry:
+
+```rust,ignore
+#[entity(table = "articles", migrations(touch_updated_at, audit, extensions = "pg_trgm"))]
+pub struct Article { /* ... */ }
+
+for ddl in Article::MIGRATION_EXTENSIONS { sqlx::query(ddl).execute(&pool).await?; }
+sqlx::query(Article::MIGRATION_UP).execute(&pool).await?;
+for ddl in Article::MIGRATION_TRIGGERS { sqlx::query(ddl).execute(&pool).await?; }
+```
+
+- `touch_updated_at` — shared `entity_touch_updated_at()` function + per-table
+  BEFORE UPDATE trigger keeping `updated_at` fresh DB-side (requires an
+  `updated_at` field, checked at compile time)
+- `audit` — `entity_audit_log` table + trigger recording `to_jsonb(OLD/NEW)`
+  diffs for INSERT/UPDATE/DELETE
+- `extensions = "..."` — idempotent `CREATE EXTENSION` statements
 
 ### PATCH Semantics
 
@@ -490,7 +515,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.17", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.18", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.15.0"
+version = "0.16.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/migrations/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres.rs
@@ -74,6 +74,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     let outbox_const = outbox_migration_const(entity);
     let junctions_const = junction_migration_const(entity);
+    let triggers_const = trigger_migration_const(entity);
+    let extensions_const = extension_migration_const(entity);
     let marker = marker::generated();
 
     quote! {
@@ -109,6 +111,10 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #outbox_const
 
             #junctions_const
+
+            #triggers_const
+
+            #extensions_const
         }
 
         const _: () = {
@@ -202,6 +208,92 @@ fn junction_migration_const(entity: &EntityDef) -> TokenStream {
         ///
         /// Execute after [`Self::MIGRATION_UP`] of both related tables.
         #vis const MIGRATION_JUNCTIONS: &'static [&'static str] = &[#(#ddls),*];
+    }
+}
+
+/// Generate the `MIGRATION_TRIGGERS` constant.
+///
+/// Emitted when `migrations(touch_updated_at)` and/or
+/// `migrations(audit)` are set. All DDL is idempotent
+/// (`CREATE OR REPLACE` / `DROP TRIGGER IF EXISTS`).
+fn trigger_migration_const(entity: &EntityDef) -> TokenStream {
+    if !entity.touch_updated_at && !entity.audit {
+        return TokenStream::new();
+    }
+
+    let vis = &entity.vis;
+    let table = entity.full_table_name();
+    let trigger_base = entity.table_name();
+    let mut ddls: Vec<String> = Vec::new();
+
+    if entity.touch_updated_at {
+        ddls.push(
+            "CREATE OR REPLACE FUNCTION entity_touch_updated_at() RETURNS TRIGGER AS $$ \
+             BEGIN NEW.updated_at = NOW(); RETURN NEW; END; $$ LANGUAGE plpgsql;"
+                .to_string()
+        );
+        ddls.push(format!(
+            "DROP TRIGGER IF EXISTS trg_{trigger_base}_touch_updated_at ON {table}; \
+             CREATE TRIGGER trg_{trigger_base}_touch_updated_at BEFORE UPDATE ON {table} \
+             FOR EACH ROW EXECUTE FUNCTION entity_touch_updated_at();"
+        ));
+    }
+
+    if entity.audit {
+        ddls.push(
+            "CREATE TABLE IF NOT EXISTS entity_audit_log (\
+                 id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY, \
+                 table_name TEXT NOT NULL, \
+                 operation TEXT NOT NULL, \
+                 old_row JSONB, \
+                 new_row JSONB, \
+                 recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW()\
+             );"
+            .to_string()
+        );
+        ddls.push(
+            "CREATE OR REPLACE FUNCTION entity_audit() RETURNS TRIGGER AS $$ \
+             BEGIN \
+                 INSERT INTO entity_audit_log (table_name, operation, old_row, new_row) \
+                 VALUES (TG_TABLE_NAME, TG_OP, to_jsonb(OLD), to_jsonb(NEW)); \
+                 RETURN COALESCE(NEW, OLD); \
+             END; $$ LANGUAGE plpgsql;"
+                .to_string()
+        );
+        ddls.push(format!(
+            "DROP TRIGGER IF EXISTS trg_{trigger_base}_audit ON {table}; \
+             CREATE TRIGGER trg_{trigger_base}_audit AFTER INSERT OR UPDATE OR DELETE ON {table} \
+             FOR EACH ROW EXECUTE FUNCTION entity_audit();"
+        ));
+    }
+
+    quote! {
+        /// Idempotent trigger DDL for this table.
+        ///
+        /// Execute after [`Self::MIGRATION_UP`]. Includes the shared
+        /// trigger functions (safe to run once per entity).
+        #vis const MIGRATION_TRIGGERS: &'static [&'static str] = &[#(#ddls),*];
+    }
+}
+
+/// Generate the `MIGRATION_EXTENSIONS` constant.
+fn extension_migration_const(entity: &EntityDef) -> TokenStream {
+    if entity.extensions.is_empty() {
+        return TokenStream::new();
+    }
+
+    let vis = &entity.vis;
+    let ddls: Vec<String> = entity
+        .extensions
+        .iter()
+        .map(|ext| format!("CREATE EXTENSION IF NOT EXISTS \"{ext}\";"))
+        .collect();
+
+    quote! {
+        /// Idempotent `CREATE EXTENSION` statements this table relies on.
+        ///
+        /// Execute before [`Self::MIGRATION_UP`].
+        #vis const MIGRATION_EXTENSIONS: &'static [&'static str] = &[#(#ddls),*];
     }
 }
 
@@ -329,5 +421,115 @@ mod junction_tests {
         let entity = EntityDef::from_derive_input(&input).unwrap();
         let code = generate(&entity).to_string();
         assert!(!code.contains("MIGRATION_JUNCTIONS"));
+    }
+}
+
+#[cfg(test)]
+mod trigger_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    #[test]
+    fn touch_updated_at_emits_function_and_trigger() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users", migrations(touch_updated_at))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub name: String,
+                #[field(response)]
+                #[auto]
+                pub updated_at: chrono::DateTime<chrono::Utc>,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(code.contains("MIGRATION_TRIGGERS"));
+        assert!(code.contains("entity_touch_updated_at"));
+        assert!(code.contains("trg_users_touch_updated_at"));
+    }
+
+    #[test]
+    fn audit_emits_log_table_and_trigger() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users", migrations(audit))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub name: String,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(code.contains("entity_audit_log"));
+        assert!(code.contains("to_jsonb(OLD)"));
+        assert!(code.contains("trg_users_audit"));
+    }
+
+    #[test]
+    fn extensions_emitted_in_order() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users", migrations(extensions = "pg_trgm, pgcrypto"))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub name: String,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(code.contains("MIGRATION_EXTENSIONS"));
+        assert!(code.contains("CREATE EXTENSION IF NOT EXISTS \\\"pg_trgm\\\";"));
+        assert!(code.contains("CREATE EXTENSION IF NOT EXISTS \\\"pgcrypto\\\";"));
+    }
+
+    #[test]
+    fn plain_migrations_have_no_new_consts() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users", migrations)]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub name: String,
+            }
+        });
+        let code = generate(&entity).to_string();
+        assert!(!code.contains("MIGRATION_TRIGGERS"));
+        assert!(!code.contains("MIGRATION_EXTENSIONS"));
+    }
+
+    #[test]
+    fn touch_without_updated_at_rejected() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "users", migrations(touch_updated_at))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub name: String,
+            }
+        };
+        let err = EntityDef::from_derive_input(&input).unwrap_err();
+        assert!(err.to_string().contains("requires an `updated_at` field"));
+    }
+
+    #[test]
+    fn unknown_migrations_option_rejected() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "users", migrations(triggers))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+            }
+        };
+        assert!(EntityDef::from_derive_input(&input).is_err());
     }
 }

--- a/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
@@ -79,6 +79,90 @@ impl darling::FromMeta for EventsAttr {
     }
 }
 
+/// Migrations configuration parsed from `#[entity(migrations)]` or
+/// `#[entity(migrations(...))]`.
+///
+/// | Form | Meaning |
+/// |------|---------|
+/// | `migrations` | `MIGRATION_UP` / `MIGRATION_DOWN` constants |
+/// | `migrations(touch_updated_at)` | + shared trigger keeping `updated_at` fresh |
+/// | `migrations(audit)` | + JSONB audit-log table and trigger |
+/// | `migrations(extensions = "pg_trgm, pgcrypto")` | + `CREATE EXTENSION` statements |
+#[derive(Debug, Clone, Default)]
+pub struct MigrationsAttr {
+    /// Whether migration generation is enabled at all.
+    pub enabled: bool,
+
+    /// Emit the shared `entity_touch_updated_at()` function and a
+    /// per-table trigger bumping `updated_at` on every UPDATE.
+    pub touch_updated_at: bool,
+
+    /// Emit the `entity_audit_log` table and a per-table trigger
+    /// recording `to_jsonb(OLD/NEW)` diffs.
+    pub audit: bool,
+
+    /// Extensions to create before the table DDL.
+    pub extensions: Vec<String>
+}
+
+impl darling::FromMeta for MigrationsAttr {
+    fn from_word() -> darling::Result<Self> {
+        Ok(Self {
+            enabled: true,
+            ..Self::default()
+        })
+    }
+
+    fn from_list(items: &[darling::ast::NestedMeta]) -> darling::Result<Self> {
+        let mut attr = Self {
+            enabled: true,
+            ..Self::default()
+        };
+        for item in items {
+            match item {
+                darling::ast::NestedMeta::Meta(syn::Meta::Path(path))
+                    if path.is_ident("touch_updated_at") =>
+                {
+                    attr.touch_updated_at = true;
+                }
+                darling::ast::NestedMeta::Meta(syn::Meta::Path(path))
+                    if path.is_ident("audit") =>
+                {
+                    attr.audit = true;
+                }
+                darling::ast::NestedMeta::Meta(syn::Meta::NameValue(nv))
+                    if nv.path.is_ident("extensions") =>
+                {
+                    let syn::Expr::Lit(syn::ExprLit {
+                        lit: syn::Lit::Str(lit),
+                        ..
+                    }) = &nv.value
+                    else {
+                        return Err(darling::Error::custom(
+                            "extensions expects a comma-separated string"
+                        )
+                        .with_span(&nv.value));
+                    };
+                    attr.extensions = lit
+                        .value()
+                        .split(',')
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string)
+                        .collect();
+                }
+                other => {
+                    return Err(darling::Error::custom(
+                        "unknown migrations option; expected touch_updated_at, audit or extensions = \"...\""
+                    )
+                    .with_span(other));
+                }
+            }
+        }
+        Ok(attr)
+    }
+}
+
 /// Default error type path for SQL implementations.
 ///
 /// Used when no custom error type is specified.
@@ -312,7 +396,7 @@ pub struct EntityAttrs {
     /// // User::MIGRATION_DOWN → DROP TABLE users CASCADE
     /// ```
     #[darling(default)]
-    pub migrations: bool,
+    pub migrations: MigrationsAttr,
 
     /// Enable aggregate root pattern.
     ///

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -158,6 +158,15 @@ impl EntityDef {
             .with_span(&input.ident));
         }
 
+        if attrs.migrations.touch_updated_at
+            && !fields.iter().any(|f| f.name_str() == "updated_at")
+        {
+            return Err(darling::Error::custom(
+                "migrations(touch_updated_at) requires an `updated_at` field"
+            )
+            .with_span(&input.ident));
+        }
+
         if let Some(upsert) = &attrs.upsert {
             validate_upsert(
                 upsert,
@@ -194,7 +203,10 @@ impl EntityDef {
             transactions: attrs.transactions,
             api_config,
             doc,
-            migrations: attrs.migrations,
+            migrations: attrs.migrations.enabled,
+            touch_updated_at: attrs.migrations.touch_updated_at,
+            audit: attrs.migrations.audit,
+            extensions: attrs.migrations.extensions,
             indexes,
             aggregate_root: attrs.aggregate_root,
             upsert: attrs.upsert

--- a/crates/entity-derive-impl/src/entity/parse/entity/def.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/def.rs
@@ -221,6 +221,15 @@ pub struct EntityDef {
     /// with SQL DDL statements for creating/dropping the table.
     pub migrations: bool,
 
+    /// Emit the shared `updated_at` trigger DDL.
+    pub touch_updated_at: bool,
+
+    /// Emit the audit-log table and trigger DDL.
+    pub audit: bool,
+
+    /// Extensions to create before the table DDL.
+    pub extensions: Vec<String>,
+
     /// Composite index definitions from `#[entity(index(...))]`.
     ///
     /// Each entry defines an index spanning multiple columns.

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.9", features = ["serde"] }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.15", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.16", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/migrations_triggers.rs
+++ b/crates/entity-derive/tests/cases/pass/migrations_triggers.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use chrono::{DateTime, Utc};
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(
+    table = "articles",
+    migrations(touch_updated_at, audit, extensions = "pg_trgm")
+)]
+pub struct Article {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub title: String,
+
+    #[field(response)]
+    #[auto]
+    pub updated_at: DateTime<Utc>,
+}
+
+fn main() {
+    assert_eq!(Article::MIGRATION_EXTENSIONS.len(), 1);
+    assert!(Article::MIGRATION_EXTENSIONS[0].contains("pg_trgm"));
+    assert!(Article::MIGRATION_TRIGGERS.len() >= 4);
+    assert!(Article::MIGRATION_TRIGGERS[0].contains("entity_touch_updated_at"));
+    assert!(
+        Article::MIGRATION_TRIGGERS
+            .iter()
+            .any(|d| d.contains("entity_audit_log"))
+    );
+    assert!(Article::MIGRATION_UP.contains("CREATE TABLE IF NOT EXISTS articles"));
+}


### PR DESCRIPTION
Closes #150.

Extends `migrations` with the DDL production tables actually carry.

## Options

- `migrations(touch_updated_at)` — shared `entity_touch_updated_at()` plpgsql function + per-table BEFORE UPDATE trigger; requires an `updated_at` field (compile-time check)
- `migrations(audit)` — `entity_audit_log` table + `entity_audit()` function + per-table AFTER INSERT/UPDATE/DELETE trigger recording `to_jsonb(OLD/NEW)` diffs
- `migrations(extensions = "pg_trgm, pgcrypto")` — idempotent `CREATE EXTENSION` statements
- New constants: `MIGRATION_TRIGGERS` (run after `MIGRATION_UP`) and `MIGRATION_EXTENSIONS` (run before); all DDL idempotent (`CREATE OR REPLACE` / `DROP TRIGGER IF EXISTS` / `IF NOT EXISTS`)
- Plain `migrations` unchanged; unknown options rejected with a clear error

## Testing

- 6 new unit tests (each option's DDL shape, gating, validation errors) — 655 total green
- trybuild pass case asserting the emitted constants
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: entity attribute quick-reference + "Migration Triggers & Extensions" section, pins 0.18
- entity-derive 0.17.0 → 0.18.0, entity-derive-impl 0.15.0 → 0.16.0
- Wiki follows after merge