### PR TITLE
154

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.9" }
-entity-derive = { path = "crates/entity-derive", version = "0.18" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.16" }
+entity-derive = { path = "crates/entity-derive", version = "0.19" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.17" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.18", features = ["postgres", "api"] }
+entity-derive = { version = "0.19", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.18", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.19", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.18", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.19", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -134,6 +134,7 @@ tracing-subscriber = "0.3"
 | **Sorting & Keyset** | `#[sort]` whitelisted ORDER BY + `list_after` cursor pagination |
 | **Bulk Operations** | `find_by_ids`, atomic `create_many`, soft-delete-aware `delete_many` |
 | **PATCH Semantics** | Dynamic UPDATE SET; double-`Option` distinguishes "leave" from "set NULL" |
+| **Optimistic Locking** | `#[version]` — guarded, auto-incremented version column |
 | **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
@@ -214,6 +215,7 @@ tracing-subscriber = "0.3"
 #[id]                          // Primary key (auto-generated UUID)
 #[auto]                        // Auto-generated (timestamps)
 #[owner]                       // Ownership column: adds *_scoped methods
+#[version]                     // Optimistic locking: guarded, auto-bumped
 #[field(create)]               // Include in CreateRequest
 #[field(update)]               // Include in UpdateRequest
 #[field(response)]             // Include in Response
@@ -318,6 +320,30 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Optimistic Locking
+
+Mark an integer column with `#[version]` and concurrent updates stop
+silently overwriting each other. The Update DTO gains a required
+`expected_version`; the generated UPDATE bumps the column and only
+applies when the stored version still matches — a stale write fails
+with a conflict error instead of clobbering newer data:
+
+```rust,ignore
+#[derive(Entity)]
+#[entity(table = "orders", migrations)]
+pub struct Order {
+    #[id] pub id: Uuid,
+    #[field(create, update, response)] pub note: String,
+    #[version] #[field(response)] #[auto] pub version: i32,
+}
+
+let patch = UpdateOrderRequest { note: Some("v2".into()), expected_version: order.version };
+let updated = pool.update(order.id, patch).await?;   // version = version + 1
+```
+
+DDL gets `INTEGER NOT NULL DEFAULT 0` automatically. Works in plain,
+scoped and transactional updates.
 
 ### Migration Triggers & Extensions
 
@@ -515,7 +541,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.18", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.19", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/dto.rs
+++ b/crates/entity-derive-impl/src/entity/dto.rs
@@ -104,6 +104,17 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
         }
     });
 
+    let version_field = entity.version_field().map(|f| {
+        let vt = f.ty();
+        quote! {
+            /// Version observed by the caller (optimistic locking).
+            ///
+            /// The UPDATE only applies when the row still carries this
+            /// version; on mismatch the call fails with a conflict.
+            pub expected_version: #vt,
+        }
+    });
+
     let marker = marker::generated();
 
     quote! {
@@ -111,7 +122,10 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
         #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
         #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
         #[cfg_attr(feature = "validate", derive(validator::Validate))]
-        #vis struct #name { #(#field_defs),* }
+        #vis struct #name {
+            #(#field_defs,)*
+            #version_field
+        }
     }
 }
 

--- a/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
@@ -144,6 +144,12 @@ impl EntityDef {
     }
 
     /// Check if this entity has any filterable fields.
+    /// Get the `#[version]` optimistic-locking field, if any.
+    #[must_use]
+    pub fn version_field(&self) -> Option<&FieldDef> {
+        self.fields.iter().find(|f| f.storage.is_version)
+    }
+
     /// Get all fields marked `#[sort]`.
     #[must_use]
     pub fn sort_fields(&self) -> Vec<&FieldDef> {

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -107,7 +107,7 @@ impl EntityDef {
     pub fn from_derive_input(input: &DeriveInput) -> darling::Result<Self> {
         let attrs = EntityAttrs::from_derive_input(input)?;
 
-        let fields: Vec<FieldDef> = match &input.data {
+        let mut fields: Vec<FieldDef> = match &input.data {
             syn::Data::Struct(data) => match &data.fields {
                 syn::Fields::Named(named) => named
                     .named
@@ -156,6 +156,38 @@ impl EntityDef {
                 "#[owner] cannot be combined with #[id]: the owner column scopes rows of another principal"
             )
             .with_span(&input.ident));
+        }
+
+        let version_fields: Vec<usize> = fields
+            .iter()
+            .enumerate()
+            .filter(|(_, f)| f.storage.is_version)
+            .map(|(i, _)| i)
+            .collect();
+        if version_fields.len() > 1 {
+            return Err(
+                darling::Error::custom("Entity can have at most one #[version] field")
+                    .with_span(&input.ident)
+            );
+        }
+        if let Some(&idx) = version_fields.first() {
+            let ty_ok = matches!(
+                &fields[idx].ty,
+                syn::Type::Path(tp) if tp
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|s| matches!(s.ident.to_string().as_str(), "i16" | "i32" | "i64"))
+            );
+            if !ty_ok {
+                return Err(darling::Error::custom(
+                    "#[version] requires an integer field (i16, i32 or i64)"
+                )
+                .with_span(&fields[idx].ident));
+            }
+            if fields[idx].column.default.is_none() {
+                fields[idx].column.default = Some("0".to_string());
+            }
         }
 
         if attrs.migrations.touch_updated_at

--- a/crates/entity-derive-impl/src/entity/parse/entity/tests.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/tests.rs
@@ -522,3 +522,56 @@ fn owner_absent_returns_none() {
     let entity = EntityDef::from_derive_input(&input).unwrap();
     assert!(entity.owner_field().is_none());
 }
+
+#[test]
+fn version_field_parsed_with_auto_default() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "orders")]
+        pub struct Order {
+            #[id]
+            pub id: uuid::Uuid,
+            #[field(create, update, response)]
+            pub note: String,
+            #[version]
+            #[field(response)]
+            #[auto]
+            pub version: i32,
+        }
+    };
+    let entity = EntityDef::from_derive_input(&input).unwrap();
+    let field = entity.version_field().unwrap();
+    assert_eq!(field.name_str(), "version");
+    assert_eq!(field.column.default.as_deref(), Some("0"));
+}
+
+#[test]
+fn version_duplicate_rejected() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "orders")]
+        pub struct Order {
+            #[id]
+            pub id: uuid::Uuid,
+            #[version]
+            pub v1: i32,
+            #[version]
+            pub v2: i32,
+        }
+    };
+    let err = EntityDef::from_derive_input(&input).unwrap_err();
+    assert!(err.to_string().contains("at most one #[version]"));
+}
+
+#[test]
+fn version_non_integer_rejected() {
+    let input: DeriveInput = syn::parse_quote! {
+        #[entity(table = "orders")]
+        pub struct Order {
+            #[id]
+            pub id: uuid::Uuid,
+            #[version]
+            pub version: String,
+        }
+    };
+    let err = EntityDef::from_derive_input(&input).unwrap_err();
+    assert!(err.to_string().contains("integer field"));
+}

--- a/crates/entity-derive-impl/src/entity/parse/field.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field.rs
@@ -178,6 +178,8 @@ impl FieldDef {
                 storage.is_owner = true;
             } else if attr.path().is_ident("sort") {
                 sortable = true;
+            } else if attr.path().is_ident("version") {
+                storage.is_version = true;
             } else if attr.path().is_ident("field") {
                 expose = ExposeConfig::from_attr(attr);
             } else if attr.path().is_ident("belongs_to") {

--- a/crates/entity-derive-impl/src/entity/parse/field/storage.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/storage.rs
@@ -62,6 +62,12 @@ pub struct StorageConfig {
     /// generated row-level scoped repository methods.
     pub is_owner: bool,
 
+    /// Optimistic-locking column (`#[version]`).
+    ///
+    /// Auto-incremented on every generated UPDATE; updates carry a
+    /// `WHERE version = expected` guard.
+    pub is_version: bool,
+
     /// Foreign key relation (`#[belongs_to(Entity)]`).
     ///
     /// Stores the related entity name. When set, generates:
@@ -120,6 +126,7 @@ mod tests {
             is_id:      false,
             is_auto:    false,
             is_owner:   false,
+            is_version: false,
             belongs_to: Some(Ident::new("User", Span::call_site())),
             on_delete:  None
         };
@@ -132,6 +139,7 @@ mod tests {
             is_id:      false,
             is_auto:    false,
             is_owner:   false,
+            is_version: false,
             belongs_to: Some(Ident::new("User", Span::call_site())),
             on_delete:  Some(ReferentialAction::Cascade)
         };

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -317,6 +317,8 @@ impl Context<'_> {
 
         let set_stmts = super::helpers::dynamic_set_stmts(&update_fields);
         let set_binds = super::helpers::dynamic_set_binds(&update_fields);
+        let (version_stmts, version_where, version_bind) =
+            super::helpers::version_guard(self.entity, &quote! { __idx + 1 });
         let _ = dialect;
 
         let span = instrument(&entity_name.to_string(), "update");
@@ -339,12 +341,15 @@ impl Context<'_> {
                     }
                     let mut tx = self.begin().await?;
                     #fetch_old
+                    #version_stmts
                     let mut q = sqlx::query_as::<_, #row_name>(
-                        ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING *", #table, __sets.join(", "), stringify!(#id_name), __idx))
+                        ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}{} RETURNING *", #table, __sets.join(", "), stringify!(#id_name), __idx, #version_where))
                     );
                     #set_binds
                     q = q.bind(&id);
-                    let row: #row_name = q.fetch_one(&mut *tx).await?;
+                    #version_bind
+                    let row: #row_name = q.fetch_optional(&mut *tx).await?
+                        .ok_or_else(|| sqlx::Error::Protocol("row not found or version conflict".into()))?;
                     let entity = #entity_name::from(row);
                     #outbox_updated
                     #notify
@@ -366,12 +371,15 @@ impl Context<'_> {
                         if __sets.is_empty() {
                             return <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound.into());
                         }
+                        #version_stmts
                         let mut q = sqlx::query_as::<_, #row_name>(
-                            ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING *", #table, __sets.join(", "), stringify!(#id_name), __idx))
+                            ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}{} RETURNING *", #table, __sets.join(", "), stringify!(#id_name), __idx, #version_where))
                         );
                         #set_binds
                         q = q.bind(&id);
-                        let row: #row_name = q.fetch_one(self).await?;
+                        #version_bind
+                        let row: #row_name = q.fetch_optional(self).await?
+                            .ok_or_else(|| sqlx::Error::Protocol("row not found or version conflict".into()))?;
                         Ok(#entity_name::from(row))
                     }
                 }
@@ -382,10 +390,15 @@ impl Context<'_> {
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
                         #set_stmts
                         if !__sets.is_empty() {
-                            let mut q = sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}", #table, __sets.join(", "), stringify!(#id_name), __idx)));
+                            #version_stmts
+                            let mut q = sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}{}", #table, __sets.join(", "), stringify!(#id_name), __idx, #version_where)));
                             #set_binds
                             q = q.bind(&id);
-                            q.execute(self).await?;
+                            #version_bind
+                            let __result = q.execute(self).await?;
+                            if __result.rows_affected() == 0 {
+                                return Err(sqlx::Error::Protocol("row not found or version conflict".into()).into());
+                            }
                         }
                         <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)
                     }
@@ -398,10 +411,15 @@ impl Context<'_> {
                     async fn update(&self, id: #id_type, dto: #update_dto) -> Result<#entity_name, Self::Error> {
                         #set_stmts
                         if !__sets.is_empty() {
-                            let mut q = sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING {}", #table, __sets.join(", "), stringify!(#id_name), __idx, #returning_cols)));
+                            #version_stmts
+                            let mut q = sqlx::query(::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}{} RETURNING {}", #table, __sets.join(", "), stringify!(#id_name), __idx, #version_where, #returning_cols)));
                             #set_binds
                             q = q.bind(&id);
-                            q.execute(self).await?;
+                            #version_bind
+                            let __result = q.execute(self).await?;
+                            if __result.rows_affected() == 0 {
+                                return Err(sqlx::Error::Protocol("row not found or version conflict".into()).into());
+                            }
                         }
                         <Self as #trait_name>::find_by_id(self, id).await?.ok_or_else(|| sqlx::Error::RowNotFound)
                     }
@@ -572,5 +590,59 @@ mod list_after_tests {
         let code = Context::new(&entity).list_after_method().to_string();
         assert!(code.contains("AND deleted_at IS NULL"));
         assert!(code.contains("WHERE deleted_at IS NULL"));
+    }
+}
+
+#[cfg(test)]
+mod version_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::super::context::Context;
+    use crate::entity::parse::EntityDef;
+
+    fn versioned_entity() -> EntityDef {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "orders")]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub note: String,
+                #[version]
+                #[field(response)]
+                #[auto]
+                pub version: i32,
+            }
+        };
+        EntityDef::from_derive_input(&input).unwrap()
+    }
+
+    #[test]
+    fn update_bumps_and_guards_version() {
+        let code = Context::new(&versioned_entity())
+            .update_method()
+            .to_string();
+        assert!(code.contains("version = version + 1"));
+        assert!(code.contains("AND version = ${}"));
+        assert!(code.contains("expected_version"));
+        assert!(code.contains("version conflict"));
+        let _ = quote!();
+    }
+
+    #[test]
+    fn update_without_version_has_no_guard() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "orders")]
+            pub struct Order {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                pub note: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let code = Context::new(&entity).update_method().to_string();
+        assert!(!code.contains("expected_version"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -234,6 +234,38 @@ pub fn dynamic_set_stmts(fields: &[&FieldDef]) -> TokenStream {
     }
 }
 
+/// Version-guard fragments for optimistic locking.
+///
+/// Returns `(set_fragment_stmt, where_fragment, bind_stmt)`:
+/// a statement pushing `version = version + 1` into `__sets`, the
+/// extra WHERE condition with its placeholder expression, and the
+/// bind of `dto.expected_version`.
+pub fn version_guard(
+    entity: &crate::entity::parse::EntityDef,
+    where_index: &TokenStream
+) -> (TokenStream, TokenStream, TokenStream) {
+    match entity.version_field() {
+        Some(field) => {
+            let column = field.name_str();
+            let bump = format!("{column} = {column} + 1");
+            let where_fmt = format!(" AND {column} = ${{}}");
+            (
+                quote! {
+                    __sets.push(#bump.to_string());
+                    let __version_where = format!(#where_fmt, #where_index);
+                },
+                quote! { __version_where },
+                quote! { q = q.bind(dto.expected_version); }
+            )
+        }
+        None => (
+            quote! { let __version_where = ""; },
+            quote! { __version_where },
+            TokenStream::new()
+        )
+    }
+}
+
 /// Generate conditional `.bind()` statements matching [`dynamic_set_stmts`].
 ///
 /// The query variable is expected to be named `q`.

--- a/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/scoped.rs
@@ -150,6 +150,8 @@ impl Context<'_> {
 
         let set_stmts = super::helpers::dynamic_set_stmts(&update_fields);
         let set_binds = super::helpers::dynamic_set_binds(&update_fields);
+        let (version_stmts, version_where, version_bind) =
+            super::helpers::version_guard(entity, &quote! { __idx + 2 });
         let _ = dialect;
         let owner_col_str = owner_col.to_string();
 
@@ -167,13 +169,16 @@ impl Context<'_> {
                 if __sets.is_empty() {
                     return self.find_by_id_scoped(id, #owner_name).await;
                 }
+                #version_stmts
+                let __owner_where = format!(" AND {} = ${}", #owner_col_str, __idx + 1);
                 let mut q = sqlx::query_as::<_, #row_name>(::sqlx::AssertSqlSafe(format!(
-                    "UPDATE {} SET {} WHERE {} = ${} AND {} = ${} RETURNING *",
-                    #table, __sets.join(", "), stringify!(#id_name), __idx, #owner_col_str, __idx + 1
+                    "UPDATE {} SET {} WHERE {} = ${}{}{} RETURNING *",
+                    #table, __sets.join(", "), stringify!(#id_name), __idx, __owner_where, #version_where
                 )));
                 #set_binds
                 q = q.bind(&id);
                 q = q.bind(&#owner_name);
+                #version_bind
                 let row: Option<#row_name> = q.fetch_optional(self).await?;
                 Ok(row.map(#entity_name::from))
             }

--- a/crates/entity-derive-impl/src/entity/transaction.rs
+++ b/crates/entity-derive-impl/src/entity/transaction.rs
@@ -111,6 +111,8 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
         let update_fields = entity.update_fields();
         let set_stmts = super::sql::postgres::helpers::dynamic_set_stmts(&update_fields);
         let set_binds = super::sql::postgres::helpers::dynamic_set_binds(&update_fields);
+        let (version_stmts, version_where, version_bind) =
+            super::sql::postgres::helpers::version_guard(entity, &quote! { __idx + 1 });
 
         quote! {
             /// Update an entity within the transaction.
@@ -127,13 +129,16 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
                 if __sets.is_empty() {
                     return self.find_by_id(id).await?.ok_or(sqlx::Error::RowNotFound);
                 }
+                #version_stmts
                 let mut q = sqlx::query_as::<_, #row_name>(
-                    ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${} RETURNING *",
-                        #table, __sets.join(", "), stringify!(#id_name), __idx))
+                    ::sqlx::AssertSqlSafe(format!("UPDATE {} SET {} WHERE {} = ${}{} RETURNING *",
+                        #table, __sets.join(", "), stringify!(#id_name), __idx, #version_where))
                 );
                 #set_binds
                 q = q.bind(&id);
-                let row: #row_name = q.fetch_one(&mut **self.tx).await?;
+                #version_bind
+                let row: #row_name = q.fetch_optional(&mut **self.tx).await?
+                    .ok_or_else(|| sqlx::Error::Protocol("row not found or version conflict".into()))?;
                 Ok(#entity_name::from(row))
             }
         }

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -469,8 +469,8 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(
     Entity,
     attributes(
-        entity, field, id, auto, owner, sort, validate, belongs_to, has_many, projection, filter,
-        command, example, column, map
+        entity, field, id, auto, owner, sort, version, validate, belongs_to, has_many, projection,
+        filter, command, example, column, map
     )
 )]
 pub fn derive_entity(input: TokenStream) -> TokenStream {

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.9", features = ["serde"] }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.16", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.17", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/version_locking.rs
+++ b/crates/entity-derive/tests/cases/pass/version_locking.rs
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "orders", migrations)]
+pub struct Order {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub note: String,
+
+    #[version]
+    #[field(response)]
+    #[auto]
+    pub version: i32,
+}
+
+async fn exercise(pool: sqlx::PgPool, order: Order) -> Result<(), sqlx::Error> {
+    let patch = UpdateOrderRequest {
+        note: Some("changed".into()),
+        expected_version: order.version,
+    };
+    let _updated: Order = pool.update(order.id, patch).await?;
+    Ok(())
+}
+
+fn main() {
+    assert!(Order::MIGRATION_UP.contains("version INTEGER NOT NULL DEFAULT 0"));
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #154.

Adds optimistic locking: concurrent updates no longer silently overwrite each other.

## `#[version]`

- Marks an integer column (`i16`/`i32`/`i64`, validated at compile time; at most one)
- Update DTO gains a required `expected_version` field
- Generated UPDATE appends `version = version + 1` to SET and `AND version = $n` to WHERE — in plain, scoped and transactional updates
- Zero affected rows surface as a conflict error ("row not found or version conflict") distinguishable from a plain missing row before the write
- DDL column defaults to `INTEGER NOT NULL DEFAULT 0` automatically

## Testing

- 5 new unit tests (parse validation incl. duplicate/non-integer, guard SQL shape, gating) — 660 total green
- trybuild pass case: versioned entity end-to-end incl. DDL default assertion
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: field quick-reference + "Optimistic Locking" section + features table, pins 0.19
- entity-derive 0.18.0 → 0.19.0, entity-derive-impl 0.16.0 → 0.17.0
- Wiki follows after merge