### PR TITLE
153

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.9" }
-entity-derive = { path = "crates/entity-derive", version = "0.19" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.17" }
+entity-derive = { path = "crates/entity-derive", version = "0.20" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.18" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.19", features = ["postgres", "api"] }
+entity-derive = { version = "0.20", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.19", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.20", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.19", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.20", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -130,7 +130,7 @@ tracing-subscriber = "0.3"
 | **Type Safe** | Change a field once, everything updates |
 | **Auto HTTP Handlers** | `api(handlers)` generates CRUD endpoints + router |
 | **`OpenAPI` Docs** | Auto-generated Swagger/OpenAPI documentation |
-| **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]` |
+| **Query Filtering** | Type-safe `#[filter]`, `#[filter(like)]`, `#[filter(range)]`, `#[filter(search)]` |
 | **Sorting & Keyset** | `#[sort]` whitelisted ORDER BY + `list_after` cursor pagination |
 | **Bulk Operations** | `find_by_ids`, atomic `create_many`, soft-delete-aware `delete_many` |
 | **PATCH Semantics** | Dynamic UPDATE SET; double-`Option` distinguishes "leave" from "set NULL" |
@@ -223,6 +223,7 @@ tracing-subscriber = "0.3"
 #[filter]                      // Exact match filter
 #[filter(like)]                // ILIKE pattern filter
 #[filter(range)]               // Range filter (from/to)
+#[filter(search)]              // Trigram substring search (pg_trgm)
 #[sort]                        // Whitelisted dynamic ORDER BY
 #[belongs_to(Entity)]          // Foreign key relation
 #[has_many(Entity)]            // One-to-many relation
@@ -320,6 +321,21 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Trigram Search
+
+`#[filter(search)]` on a text column gives the Query struct a fuzzy
+substring filter (`col ILIKE '%' || $n || '%'`), while `migrations`
+emit the matching `gin_trgm_ops` index and add `pg_trgm` to
+`MIGRATION_EXTENSIONS` automatically:
+
+```rust,ignore
+#[field(create, update, response)]
+#[filter(search)]
+pub title: String,
+
+let hits = pool.query(ArticleQuery { title: Some("rust".into()), ..Default::default() }).await?;
+```
 
 ### Optimistic Locking
 
@@ -541,7 +557,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.19", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.20", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.17.0"
+version = "0.18.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/migrations/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres.rs
@@ -41,7 +41,16 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     let entity_name = entity.name();
     let vis = &entity.vis;
 
-    let up_sql = ddl::generate_up(entity);
+    let mut up_sql = ddl::generate_up(entity);
+    for field in entity.search_fields() {
+        let column = field.name_str();
+        let table = entity.full_table_name();
+        let base = entity.table_name();
+        up_sql.push_str(&format!(
+            " CREATE INDEX IF NOT EXISTS idx_{base}_{column}_trgm \
+             ON {table} USING gin ({column} gin_trgm_ops);"
+        ));
+    }
     let down_sql = ddl::generate_down(entity);
 
     let enum_fields: Vec<(&Type, String)> = entity
@@ -278,13 +287,16 @@ fn trigger_migration_const(entity: &EntityDef) -> TokenStream {
 
 /// Generate the `MIGRATION_EXTENSIONS` constant.
 fn extension_migration_const(entity: &EntityDef) -> TokenStream {
-    if entity.extensions.is_empty() {
+    let mut extensions: Vec<String> = entity.extensions.clone();
+    if !entity.search_fields().is_empty() && !extensions.iter().any(|e| e == "pg_trgm") {
+        extensions.push("pg_trgm".to_string());
+    }
+    if extensions.is_empty() {
         return TokenStream::new();
     }
 
     let vis = &entity.vis;
-    let ddls: Vec<String> = entity
-        .extensions
+    let ddls: Vec<String> = extensions
         .iter()
         .map(|ext| format!("CREATE EXTENSION IF NOT EXISTS \"{ext}\";"))
         .collect();
@@ -531,5 +543,59 @@ mod trigger_tests {
             }
         };
         assert!(EntityDef::from_derive_input(&input).is_err());
+    }
+}
+
+#[cfg(test)]
+mod search_tests {
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn search_entity() -> EntityDef {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "articles", migrations)]
+            pub struct Article {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                #[filter(search)]
+                pub title: String,
+            }
+        };
+        EntityDef::from_derive_input(&input).unwrap()
+    }
+
+    #[test]
+    fn search_filter_emits_trgm_index_and_extension() {
+        let code = generate(&search_entity()).to_string();
+        assert!(code.contains("idx_articles_title_trgm"));
+        assert!(code.contains("gin_trgm_ops"));
+        assert!(code.contains("pg_trgm"));
+    }
+
+    #[test]
+    fn search_on_non_string_rejected() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "articles")]
+            pub struct Article {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[filter(search)]
+                pub views: i64,
+            }
+        };
+        let err = EntityDef::from_derive_input(&input).unwrap_err();
+        assert!(err.to_string().contains("requires a String field"));
+    }
+
+    #[test]
+    fn search_condition_uses_contains_ilike() {
+        let entity = search_entity();
+        let code = crate::entity::sql::postgres::Context::new(&entity)
+            .query_method()
+            .to_string();
+        assert!(code.contains("ILIKE '%' || ${} || '%'"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
@@ -150,6 +150,15 @@ impl EntityDef {
         self.fields.iter().find(|f| f.storage.is_version)
     }
 
+    /// Get all fields with `#[filter(search)]` trigram filters.
+    #[must_use]
+    pub fn search_fields(&self) -> Vec<&FieldDef> {
+        self.fields
+            .iter()
+            .filter(|f| matches!(f.filter.filter_type, super::super::FilterType::Search))
+            .collect()
+    }
+
     /// Get all fields marked `#[sort]`.
     #[must_use]
     pub fn sort_fields(&self) -> Vec<&FieldDef> {

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -190,6 +190,25 @@ impl EntityDef {
             }
         }
 
+        for field in &fields {
+            if matches!(
+                field.filter.filter_type,
+                super::super::field::FilterType::Search
+            ) && !matches!(
+                &field.ty,
+                syn::Type::Path(tp) if tp
+                    .path
+                    .segments
+                    .last()
+                    .is_some_and(|s| s.ident == "String")
+            ) {
+                return Err(
+                    darling::Error::custom("#[filter(search)] requires a String field")
+                        .with_span(&field.ident)
+                );
+            }
+        }
+
         if attrs.migrations.touch_updated_at
             && !fields.iter().any(|f| f.name_str() == "updated_at")
         {

--- a/crates/entity-derive-impl/src/entity/parse/field/filter.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/filter.rs
@@ -29,6 +29,12 @@ pub enum FilterType {
     /// The value should include wildcards (e.g., `%search%`).
     Like,
 
+    /// Trigram substring search filter.
+    ///
+    /// Generates: `WHERE field ILIKE '%' || $n || '%'` and a
+    /// `gin_trgm_ops` index (plus `pg_trgm`) in migrations.
+    Search,
+
     /// Range filter for comparable types.
     ///
     /// Generates two optional fields:
@@ -66,6 +72,7 @@ impl FilterConfig {
                 "eq" => FilterType::Eq,
                 "like" => FilterType::Like,
                 "range" => FilterType::Range,
+                "search" => FilterType::Search,
                 _ => FilterType::Eq
             });
 

--- a/crates/entity-derive-impl/src/entity/query.rs
+++ b/crates/entity-derive-impl/src/entity/query.rs
@@ -67,7 +67,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             let filter = f.filter();
 
             match filter.filter_type {
-                FilterType::Eq | FilterType::Like => {
+                FilterType::Eq | FilterType::Like | FilterType::Search => {
                     vec![quote! { pub #name: Option<#ty> }]
                 }
                 FilterType::Range => {

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -92,6 +92,14 @@ pub fn generate_where_conditions(fields: &[&FieldDef], soft_delete: bool) -> Tok
                         }
                     }]
                 }
+                FilterType::Search => {
+                    vec![quote! {
+                        if query.#name.is_some() {
+                            conditions.push(format!("{} ILIKE '%' || ${} || '%'", #name_str, param_idx));
+                            param_idx += 1;
+                        }
+                    }]
+                }
                 FilterType::Range => {
                     let from_name = format_ident!("{}_from", name);
                     let to_name = format_ident!("{}_to", name);
@@ -163,6 +171,13 @@ pub fn generate_query_bindings(fields: &[&FieldDef]) -> TokenStream {
                                 .replace('%', "\\%")
                                 .replace('_', "\\_");
                             q = q.bind(format!("%{}%", escaped));
+                        }
+                    }]
+                }
+                FilterType::Search => {
+                    vec![quote! {
+                        if let Some(ref v) = query.#name {
+                            q = q.bind(v);
                         }
                     }]
                 }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.9", features = ["serde"] }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.17", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.18", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/search_filter.rs
+++ b/crates/entity-derive/tests/cases/pass/search_filter.rs
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "articles", migrations)]
+pub struct Article {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[filter(search)]
+    pub title: String,
+}
+
+async fn exercise(pool: sqlx::PgPool) -> Result<(), sqlx::Error> {
+    let query = ArticleQuery {
+        title: Some("rust".into()),
+        limit: Some(10),
+        ..Default::default()
+    };
+    let _hits: Vec<Article> = pool.query(query).await?;
+    Ok(())
+}
+
+fn main() {
+    assert!(Article::MIGRATION_UP.contains("idx_articles_title_trgm"));
+    assert!(Article::MIGRATION_EXTENSIONS[0].contains("pg_trgm"));
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #153.

Adds fuzzy substring search to the filter family.

## `#[filter(search)]`

- Query struct gains the field as `Option<String>`; SQL condition `col ILIKE '%' || $n || '%'` — the term is bound, wildcards in user input carry no special meaning beyond ILIKE semantics
- `migrations` emit `CREATE INDEX ... USING gin (col gin_trgm_ops)` in `MIGRATION_UP` and auto-add `pg_trgm` to `MIGRATION_EXTENSIONS` (deduplicated with explicit lists)
- Compile-time validation: search requires a `String` field
- Similarity ranking deliberately deferred: `ORDER BY` is owned by the `#[sort]` whitelist; mixing rank expressions in would bypass it

## Testing

- 3 new unit tests (index+extension emission, non-String rejection, ILIKE condition shape) — 663 total green
- trybuild pass case asserting DDL constants and query usage
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: filter quick-reference + "Trigram Search" section, pins 0.20
- entity-derive 0.19.0 → 0.20.0, entity-derive-impl 0.17.0 → 0.18.0
- Wiki (Filtering ×5) follows after merge