### PR TITLE
152

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ license = "MIT"
 repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
-entity-core = { path = "crates/entity-core", version = "0.9" }
-entity-derive = { path = "crates/entity-derive", version = "0.20" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.18" }
+entity-core = { path = "crates/entity-core", version = "0.10" }
+entity-derive = { path = "crates/entity-derive", version = "0.21" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.19" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.20", features = ["postgres", "api"] }
+entity-derive = { version = "0.21", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.20", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.21", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.20", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.21", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -135,6 +135,7 @@ tracing-subscriber = "0.3"
 | **Bulk Operations** | `find_by_ids`, atomic `create_many`, soft-delete-aware `delete_many` |
 | **PATCH Semantics** | Dynamic UPDATE SET; double-`Option` distinguishes "leave" from "set NULL" |
 | **Optimistic Locking** | `#[version]` — guarded, auto-incremented version column |
+| **Typed Constraint Errors** | `typed_constraints` — violations resolved to `ConstraintError` with field info |
 | **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
@@ -187,6 +188,7 @@ tracing-subscriber = "0.3"
         audit,                 // JSONB audit-log table + trigger
         extensions = "pg_trgm",// CREATE EXTENSION statements
     ),
+    typed_constraints,         // Optional: constraint violations as typed errors
     upsert(                    // Optional: INSERT ... ON CONFLICT method
         conflict = "email",    // #[column(unique)] field(s) or unique_index columns
         action = "update",     // "update" (default) or "nothing"
@@ -321,6 +323,30 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Typed Constraint Errors
+
+The macro knows every constraint it creates. With `typed_constraints`,
+write methods resolve violated constraint names and surface
+`entity_core::ConstraintError { kind, constraint, field }` instead of a
+raw driver error — no string-matching constraint names in handlers:
+
+```rust,ignore
+#[entity(table = "users", typed_constraints, error = "AppError")]
+pub struct User {
+    #[id] pub id: Uuid,
+    #[field(create, response)] #[column(unique)] pub email: String,
+}
+
+match pool.create(dto).await {
+    Err(AppError::Constraint(v)) if v.field == Some("email") => conflict_409(),
+    other => other?,
+}
+```
+
+Covers unique columns, `belongs_to` foreign keys, column checks and
+`unique_index` names. The custom `error` type must implement
+`From<ConstraintError>`; without the flag behavior is unchanged.
 
 ### Trigram Search
 
@@ -557,7 +583,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.20", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.21", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.9.0"
+version = "0.10.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -323,6 +323,42 @@ mod tests {
     use super::*;
 
     #[test]
+    fn constraint_error_display_unique_field() {
+        let err = ConstraintError {
+            kind:       ConstraintKind::Unique,
+            constraint: "users_email_key".to_string(),
+            field:      Some("email")
+        };
+        assert_eq!(err.to_string(), "duplicate value for unique field `email`");
+    }
+
+    #[test]
+    fn constraint_error_display_fk_field() {
+        let err = ConstraintError {
+            kind:       ConstraintKind::ForeignKey,
+            constraint: "orders_user_id_fkey".to_string(),
+            field:      Some("user_id")
+        };
+        assert_eq!(
+            err.to_string(),
+            "referenced row missing for field `user_id`"
+        );
+    }
+
+    #[test]
+    fn constraint_error_display_unknown_field() {
+        let err = ConstraintError {
+            kind:       ConstraintKind::Check,
+            constraint: "orders_amount_check".to_string(),
+            field:      None
+        };
+        assert_eq!(
+            err.to_string(),
+            "Check constraint `orders_amount_check` violated"
+        );
+    }
+
+    #[test]
     fn pagination_new() {
         let p = Pagination::new(50, 100);
         assert_eq!(p.limit, 50);
@@ -506,3 +542,54 @@ pub mod serde_helpers {
         }
     }
 }
+
+/// Kind of database constraint that was violated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ConstraintKind {
+    /// UNIQUE constraint or unique index.
+    Unique,
+
+    /// FOREIGN KEY constraint.
+    ForeignKey,
+
+    /// CHECK constraint.
+    Check
+}
+
+/// A database constraint violation resolved to entity metadata.
+///
+/// Produced by repositories generated with
+/// `#[entity(typed_constraints)]`: the generated code matches the
+/// violated constraint name against the set of constraints it created
+/// (unique columns, foreign keys, unique indexes) and hands callers a
+/// structured error instead of a raw driver error.
+///
+/// The repository `Error` type must implement
+/// `From<ConstraintError>` in addition to `From<sqlx::Error>`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstraintError {
+    /// What kind of constraint was violated.
+    pub kind: ConstraintKind,
+
+    /// Constraint name as reported by the database.
+    pub constraint: String,
+
+    /// Entity field the constraint maps to, when known.
+    pub field: Option<&'static str>
+}
+
+impl std::fmt::Display for ConstraintError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match (self.kind, self.field) {
+            (ConstraintKind::Unique, Some(field)) => {
+                write!(f, "duplicate value for unique field `{field}`")
+            }
+            (ConstraintKind::ForeignKey, Some(field)) => {
+                write!(f, "referenced row missing for field `{field}`")
+            }
+            (kind, _) => write!(f, "{kind:?} constraint `{}` violated", self.constraint)
+        }
+    }
+}
+
+impl std::error::Error for ConstraintError {}

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
@@ -418,5 +418,15 @@ pub struct EntityAttrs {
     /// #[entity(table = "members", unique_index(tenant_id, email), upsert(conflict = "tenant_id, email", action = "nothing"))]
     /// ```
     #[darling(default)]
-    pub upsert: Option<UpsertDef>
+    pub upsert: Option<UpsertDef>,
+
+    /// Map database constraint violations to typed errors.
+    ///
+    /// When enabled, generated write methods resolve violated
+    /// constraint names against the entity's known constraints and
+    /// surface `entity_core::ConstraintError` through the repository
+    /// `Error` type, which must additionally implement
+    /// `From<entity_core::ConstraintError>`.
+    #[darling(default)]
+    pub typed_constraints: bool
 }

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -260,7 +260,8 @@ impl EntityDef {
             extensions: attrs.migrations.extensions,
             indexes,
             aggregate_root: attrs.aggregate_root,
-            upsert: attrs.upsert
+            upsert: attrs.upsert,
+            typed_constraints: attrs.typed_constraints
         })
     }
 }

--- a/crates/entity-derive-impl/src/entity/parse/entity/def.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/def.rs
@@ -247,5 +247,8 @@ pub struct EntityDef {
     /// When present, an `upsert` repository method is generated using
     /// `INSERT ... ON CONFLICT`. Conflict columns are validated at parse
     /// time against uniqueness guarantees.
-    pub upsert: Option<UpsertDef>
+    pub upsert: Option<UpsertDef>,
+
+    /// Whether typed constraint-violation errors are enabled.
+    pub typed_constraints: bool
 }

--- a/crates/entity-derive-impl/src/entity/sql/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres.rs
@@ -61,6 +61,7 @@
 //! Generated code is gated behind `#[cfg(feature = "postgres")]`.
 
 mod bulk;
+mod constraints;
 mod context;
 mod crud;
 mod lookup;
@@ -122,10 +123,13 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     let scoped_impls = ctx.scoped_methods();
     let lookup_impls = ctx.lookup_methods();
     let save_impl = ctx.save_method();
+    let constraint_mapper = ctx.constraint_mapper();
     let marker = marker::generated();
 
     quote! {
         #marker
+        #constraint_mapper
+
         #[cfg(feature = #feature)]
         #[async_trait::async_trait]
         impl #trait_name for sqlx::PgPool {

--- a/crates/entity-derive-impl/src/entity/sql/postgres/bulk.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/bulk.rs
@@ -80,6 +80,7 @@ impl Context<'_> {
         let span = instrument(&entity_name.to_string(), "create_many");
         let outbox_created = self.outbox_created();
         let notify = self.notify_created();
+        let constraint_map_err = self.constraint_map_err();
 
         let insert_row = if matches!(returning, ReturningMode::Full) {
             quote! {
@@ -87,14 +88,14 @@ impl Context<'_> {
                     concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ") RETURNING *")
                 )
                     #(#bindings)*
-                    .fetch_one(&mut *tx).await?;
+                    .fetch_one(&mut *tx).await #constraint_map_err?;
                 let entity = #entity_name::from(row);
             }
         } else {
             quote! {
                 sqlx::query(concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ")"))
                     #(#bindings)*
-                    .execute(&mut *tx).await?;
+                    .execute(&mut *tx).await #constraint_map_err?;
             }
         };
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Typed constraint-violation mapping for `PostgreSQL`.
+//!
+//! With `#[entity(typed_constraints)]`, generated write methods resolve
+//! the violated constraint name (as reported by Postgres) against the
+//! constraints the macro itself created and surface
+//! `entity_core::ConstraintError` instead of a raw driver error.
+//!
+//! # Known Constraint Names
+//!
+//! | Source | Postgres default name |
+//! |--------|----------------------|
+//! | `#[column(unique)]` | `{table}_{column}_key` |
+//! | `#[belongs_to(...)]` | `{table}_{column}_fkey` |
+//! | `#[column(check = "...")]` | `{table}_{column}_check` |
+//! | `unique_index(...)` | index name (`idx_{table}_{cols}` or custom) |
+//!
+//! The repository `Error` type must implement
+//! `From<entity_core::ConstraintError>`.
+
+use proc_macro2::TokenStream;
+use quote::{format_ident, quote};
+
+use super::context::Context;
+
+impl Context<'_> {
+    /// Name of the generated error-mapping helper function.
+    pub fn constraint_mapper_name(&self) -> syn::Ident {
+        format_ident!(
+            "__{}_map_constraint_err",
+            self.entity.name_str().to_lowercase()
+        )
+    }
+
+    /// Generate the constraint registry and mapping helper.
+    ///
+    /// # Returns
+    ///
+    /// Empty `TokenStream` without `#[entity(typed_constraints)]`.
+    pub fn constraint_mapper(&self) -> TokenStream {
+        if !self.entity.typed_constraints {
+            return TokenStream::new();
+        }
+
+        let table = self.entity.table_name();
+        let mut arms: Vec<TokenStream> = Vec::new();
+
+        for field in self.entity.all_fields() {
+            let column = field.name_str();
+            if field.column.unique {
+                let name = format!("{table}_{column}_key");
+                arms.push(quote! {
+                    #name => Some((::entity_core::ConstraintKind::Unique, Some(#column))),
+                });
+            }
+            if field.belongs_to().is_some() {
+                let name = format!("{table}_{column}_fkey");
+                arms.push(quote! {
+                    #name => Some((::entity_core::ConstraintKind::ForeignKey, Some(#column))),
+                });
+            }
+            if field.column.check.is_some() {
+                let name = format!("{table}_{column}_check");
+                arms.push(quote! {
+                    #name => Some((::entity_core::ConstraintKind::Check, Some(#column))),
+                });
+            }
+        }
+
+        for index in &self.entity.indexes {
+            if index.unique {
+                let name = index.name_or_default(table);
+                arms.push(quote! {
+                    #name => Some((::entity_core::ConstraintKind::Unique, None)),
+                });
+            }
+        }
+
+        let fn_name = self.constraint_mapper_name();
+        let error_type = self.entity.error_type();
+
+        quote! {
+            /// Resolve a driver error against this entity's constraints.
+            #[cfg(feature = "postgres")]
+            fn #fn_name(err: ::sqlx::Error) -> #error_type {
+                if let Some(db_err) = err.as_database_error()
+                    && let Some(constraint) = db_err.constraint()
+                {
+                    let resolved: Option<(::entity_core::ConstraintKind, Option<&'static str>)> =
+                        match constraint {
+                            #(#arms)*
+                            _ => None
+                        };
+                    if let Some((kind, field)) = resolved {
+                        return ::entity_core::ConstraintError {
+                            kind,
+                            constraint: constraint.to_string(),
+                            field
+                        }
+                        .into();
+                    }
+                }
+                err.into()
+            }
+        }
+    }
+
+    /// `.map_err(mapper)` fragment for write paths, or empty tokens.
+    pub fn constraint_map_err(&self) -> TokenStream {
+        if !self.entity.typed_constraints {
+            return TokenStream::new();
+        }
+        let fn_name = self.constraint_mapper_name();
+        quote! { .map_err(#fn_name) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::super::context::Context;
+    use crate::entity::parse::EntityDef;
+
+    fn typed_entity() -> EntityDef {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "users", typed_constraints, error = "MyError", unique_index(tenant_id, email))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[column(unique)]
+                pub email: String,
+                #[field(create, response)]
+                pub tenant_id: uuid::Uuid,
+                #[field(create, response)]
+                #[belongs_to(Org)]
+                pub org_id: uuid::Uuid,
+                #[field(create, response)]
+                #[column(check = "age >= 0")]
+                pub age: i32,
+            }
+        };
+        EntityDef::from_derive_input(&input).unwrap()
+    }
+
+    #[test]
+    fn mapper_covers_all_constraint_sources() {
+        let entity = typed_entity();
+        let code = Context::new(&entity).constraint_mapper().to_string();
+        assert!(code.contains("users_email_key"));
+        assert!(code.contains("users_org_id_fkey"));
+        assert!(code.contains("users_age_check"));
+        assert!(code.contains("idx_users_tenant_id_email"));
+        assert!(code.contains("ConstraintError"));
+        let _ = quote!();
+    }
+
+    #[test]
+    fn mapper_absent_without_flag() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "users")]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[column(unique)]
+                pub email: String,
+            }
+        };
+        let entity = EntityDef::from_derive_input(&input).unwrap();
+        let ctx = Context::new(&entity);
+        assert!(ctx.constraint_mapper().is_empty());
+        assert!(ctx.constraint_map_err().is_empty());
+    }
+}

--- a/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/crud.rs
@@ -152,6 +152,7 @@ impl Context<'_> {
             ..
         } = self;
         let bindings = insert_bindings(entity.all_fields());
+        let constraint_map_err = self.constraint_map_err();
 
         let span = instrument(&entity_name.to_string(), "create");
         // When `streams` is on, the DML and the `pg_notify` must commit as
@@ -175,7 +176,7 @@ impl Context<'_> {
                             concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ") RETURNING *")
                         )
                             #(#bindings)*
-                            .fetch_one(#executor).await?;
+                            .fetch_one(#executor).await #constraint_map_err?;
                         let entity = #entity_name::from(row);
                         #outbox_created
                         #notify
@@ -194,7 +195,7 @@ impl Context<'_> {
                         let insertable = #insertable_name::from(&entity);
                         sqlx::query(concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ") RETURNING ", stringify!(#id_name)))
                             #(#bindings)*
-                            .execute(#executor).await?;
+                            .execute(#executor).await #constraint_map_err?;
                         #outbox_created
                         #notify
                         #tx_close
@@ -211,7 +212,7 @@ impl Context<'_> {
                         let insertable = #insertable_name::from(&entity);
                         sqlx::query(concat!("INSERT INTO ", #table, " (", #columns_str, ") VALUES (", #placeholders_str, ")"))
                             #(#bindings)*
-                            .execute(#executor).await?;
+                            .execute(#executor).await #constraint_map_err?;
                         #outbox_created
                         #notify
                         #tx_close
@@ -229,7 +230,7 @@ impl Context<'_> {
                         let insertable = #insertable_name::from(&entity);
                         sqlx::query(::sqlx::AssertSqlSafe(format!("INSERT INTO {} ({}) VALUES ({}) RETURNING {}", #table, #columns_str, #placeholders_str, #returning_cols)))
                             #(#bindings)*
-                            .execute(#executor).await?;
+                            .execute(#executor).await #constraint_map_err?;
                         #outbox_created
                         #notify
                         #tx_close
@@ -459,6 +460,7 @@ impl Context<'_> {
         // statement otherwise — no perf regression for non-streams entities.
         let (tx_open, tx_close, executor) = tx_wrapping(*streams || self.outbox);
         let outbox_deleted = self.outbox_deleted();
+        let constraint_map_err = self.constraint_map_err();
 
         if *soft_delete {
             let notify = self.notify_soft_deleted();
@@ -470,7 +472,7 @@ impl Context<'_> {
                     let result = sqlx::query(::sqlx::AssertSqlSafe(format!(
                         "UPDATE {} SET deleted_at = NOW() WHERE {} = {} AND deleted_at IS NULL",
                         #table, stringify!(#id_name), #placeholder
-                    ))).bind(&id).execute(#executor).await?;
+                    ))).bind(&id).execute(#executor).await #constraint_map_err?;
                     let deleted = result.rows_affected() > 0;
                     if deleted {
                         #outbox_deleted
@@ -488,7 +490,7 @@ impl Context<'_> {
                 async fn delete(&self, id: #id_type) -> Result<bool, Self::Error> {
                     #tx_open
                     let result = sqlx::query(::sqlx::AssertSqlSafe(format!("DELETE FROM {} WHERE {} = {}", #table, stringify!(#id_name), #placeholder)))
-                        .bind(&id).execute(#executor).await?;
+                        .bind(&id).execute(#executor).await #constraint_map_err?;
                     let deleted = result.rows_affected() > 0;
                     if deleted {
                         #outbox_deleted

--- a/crates/entity-derive-impl/src/entity/sql/postgres/upsert.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/upsert.rs
@@ -64,6 +64,7 @@ impl Context<'_> {
         let (tx_open, tx_close, executor) = tx_wrapping(*streams || self.outbox);
         let outbox_created = self.outbox_created();
         let notify = self.notify_created();
+        let constraint_map_err = self.constraint_map_err();
         let sql = self.upsert_sql();
 
         match upsert.action {
@@ -76,7 +77,7 @@ impl Context<'_> {
                         let insertable = #insertable_name::from(&entity);
                         let row: #row_name = sqlx::query_as(#sql)
                             #(#bindings)*
-                            .fetch_one(#executor).await?;
+                            .fetch_one(#executor).await #constraint_map_err?;
                         let entity = #entity_name::from(row);
                         #outbox_created
                         #notify
@@ -94,7 +95,7 @@ impl Context<'_> {
                         let insertable = #insertable_name::from(&entity);
                         let row: Option<#row_name> = sqlx::query_as(#sql)
                             #(#bindings)*
-                            .fetch_optional(#executor).await?;
+                            .fetch_optional(#executor).await #constraint_map_err?;
                         match row {
                             Some(row) => {
                                 let entity = #entity_name::from(row);

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.20.0"
+version = "0.21.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -74,8 +74,8 @@ projections = ["entity-derive-impl/projections"]
 tracing = ["entity-core/tracing"]
 
 [dependencies]
-entity-core = { path = "../entity-core", version = "0.9", features = ["serde"] }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.18", default-features = false }
+entity-core = { path = "../entity-core", version = "0.10", features = ["serde"] }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.19", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/pass/typed_constraints.rs
+++ b/crates/entity-derive/tests/cases/pass/typed_constraints.rs
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_core::ConstraintError;
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug)]
+pub enum AppError {
+    Database(sqlx::Error),
+    Constraint(ConstraintError),
+}
+
+impl std::fmt::Display for AppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Database(e) => write!(f, "database error: {e}"),
+            Self::Constraint(e) => write!(f, "constraint violation: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for AppError {}
+
+impl From<sqlx::Error> for AppError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Database(e)
+    }
+}
+
+impl From<ConstraintError> for AppError {
+    fn from(e: ConstraintError) -> Self {
+        Self::Constraint(e)
+    }
+}
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "users", typed_constraints, error = "AppError")]
+pub struct User {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, response)]
+    #[column(unique)]
+    pub email: String,
+
+    #[field(create, update, response)]
+    pub name: String,
+}
+
+async fn exercise(pool: sqlx::PgPool) -> Result<(), AppError> {
+    let result = pool
+        .create(CreateUserRequest {
+            email: "a@b.c".into(),
+            name: "A".into(),
+        })
+        .await;
+    if let Err(AppError::Constraint(violation)) = &result {
+        assert_eq!(violation.field, Some("email"));
+    }
+    let _ = result;
+    Ok(())
+}
+
+fn main() {
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #152.

The macro knows every constraint it creates — with `#[entity(typed_constraints)]` write methods stop leaking raw driver errors for violations.

## Behavior

- Generated `create`/`create_many`/`upsert`/`delete` paths map violated constraint names against the entity's registry: unique columns (`{table}_{col}_key`), `belongs_to` FKs (`{table}_{col}_fkey`), column checks (`{table}_{col}_check`) and `unique_index` names
- Matches surface as `entity_core::ConstraintError { kind: Unique|ForeignKey|Check, constraint, field }` (new runtime type with human-readable `Display`); unknown constraints and other errors pass through unchanged
- Opt-in: requires a custom `error` type implementing `From<ConstraintError>`; without the flag nothing changes
- Mapper is `#[cfg(feature = "postgres")]`-gated like the repository impl

## Testing

- 3 runtime-type tests + 2 registry/codegen tests — 665 impl + 48 core green
- trybuild pass case: custom error enum with both `From` impls, field-level match on violation
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: entity quick-reference + "Typed Constraint Errors" section + features table, pins 0.21
- entity-core 0.9.0 → 0.10.0, entity-derive-impl 0.18.0 → 0.19.0, entity-derive 0.20.0 → 0.21.0
- Wiki follows after merge