### PR TITLE
151

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,8 @@ repository = "https://github.com/RAprogramm/entity-derive"
 
 [workspace.dependencies]
 entity-core = { path = "crates/entity-core", version = "0.10" }
-entity-derive = { path = "crates/entity-derive", version = "0.21" }
-entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.19" }
+entity-derive = { path = "crates/entity-derive", version = "0.22" }
+entity-derive-impl = { path = "crates/entity-derive-impl", version = "0.20" }
 syn = { version = "2", features = ["full", "extra-traits", "parsing"] }
 quote = "1"
 proc-macro2 = "1"

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ pub struct User {
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.21", features = ["postgres", "api"] }
+entity-derive = { version = "0.22", features = ["postgres", "api"] }
 ```
 
 ### Feature flags
@@ -106,7 +106,7 @@ Default features cover the full entity-attribute surface so existing projects wo
 ```toml
 [dependencies]
 # Just repositories — no events, hooks, commands, etc.
-entity-derive = { version = "0.21", default-features = false, features = ["postgres"] }
+entity-derive = { version = "0.22", default-features = false, features = ["postgres"] }
 ```
 
 If you use an entity attribute whose feature is disabled (e.g. `#[entity(commands)]` without `features = ["commands"]`), the macro emits a `compile_error!` at the attribute pointing to the missing feature.
@@ -115,7 +115,7 @@ Enable extras alongside the defaults:
 
 ```toml
 [dependencies]
-entity-derive = { version = "0.21", features = ["postgres", "api", "tracing", "streams"] }
+entity-derive = { version = "0.22", features = ["postgres", "api", "tracing", "streams"] }
 tracing = "0.1"
 tracing-subscriber = "0.3"
 ```
@@ -136,6 +136,7 @@ tracing-subscriber = "0.3"
 | **PATCH Semantics** | Dynamic UPDATE SET; double-`Option` distinguishes "leave" from "set NULL" |
 | **Optimistic Locking** | `#[version]` — guarded, auto-incremented version column |
 | **Typed Constraint Errors** | `typed_constraints` — violations resolved to `ConstraintError` with field info |
+| **Embedded Value Objects** | `#[embed(prefix, fields(...))]` — structs flattened to prefixed columns |
 | **Relations** | `#[belongs_to]`, `#[has_many]` and many-to-many via `through = "junction"` |
 | **Ownership Scoping** | `#[owner]` generates `find_by_id_scoped` / `list_by_owner` / `update_scoped` / `delete_scoped` |
 | **Upsert** | `upsert(conflict = "…")` generates `INSERT ... ON CONFLICT DO UPDATE / DO NOTHING` |
@@ -218,6 +219,7 @@ tracing-subscriber = "0.3"
 #[auto]                        // Auto-generated (timestamps)
 #[owner]                       // Ownership column: adds *_scoped methods
 #[version]                     // Optimistic locking: guarded, auto-bumped
+#[embed(prefix, fields(...))]  // Flatten a value object to prefixed columns
 #[field(create)]               // Include in CreateRequest
 #[field(update)]               // Include in UpdateRequest
 #[field(response)]             // Include in Response
@@ -323,6 +325,30 @@ pub struct User { /* ... */ }
 Per-operation overrides accept `create`, `get`, `update`, `delete`, `list`
 and `commands`; the literal `"none"` disables the guard for that operation.
 Commands listed in `public = [...]` never receive a guard.
+
+### Embedded Value Objects
+
+Keep money-style value objects as real structs on the entity while
+storing them as flat scalar columns — no JSONB detour:
+
+```rust,ignore
+pub struct Money { pub amount_cents: i64, pub currency: String }
+
+#[derive(Entity)]
+#[entity(table = "products", migrations)]
+pub struct Product {
+    #[id] pub id: Uuid,
+    #[field(create, update, response)]
+    #[embed(prefix = "price_", fields(amount_cents: i64, currency: String))]
+    pub price: Money,
+}
+```
+
+DDL, Row struct, CRUD SQL and dynamic updates operate on
+`price_amount_cents` / `price_currency`; DTOs and the entity carry
+`Money` itself. The declared shape is destructured against the real
+struct at compile time — a renamed, retyped, missing or extra field
+fails the build. `Option<Money>` parents are not supported yet.
 
 ### Typed Constraint Errors
 
@@ -583,7 +609,7 @@ projections, transaction adapters, stream subscribers) is wrapped in
 `#[tracing::instrument(skip_all, fields(entity, op), err(Debug))]`.
 
 ```toml
-entity-derive = { version = "0.21", features = ["postgres", "tracing"] }
+entity-derive = { version = "0.22", features = ["postgres", "tracing"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 ```

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.19.0"
+version = "0.20.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/src/entity/insertable.rs
+++ b/crates/entity-derive-impl/src/entity/insertable.rs
@@ -73,11 +73,15 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     let vis = &entity.vis;
     let insertable_name = entity.ident_with("Insertable", "");
-    let field_defs = entity.all_fields().iter().map(|f| {
-        let name = f.name();
-        let ty = f.ty();
-        quote! { pub #name: #ty }
-    });
+    let field_defs = entity
+        .all_fields()
+        .iter()
+        .filter(|f| f.embed.is_none())
+        .map(|f| {
+            let name = f.name();
+            let ty = f.ty();
+            quote! { pub #name: #ty }
+        });
 
     let marker = marker::generated();
 

--- a/crates/entity-derive-impl/src/entity/mappers.rs
+++ b/crates/entity-derive-impl/src/entity/mappers.rs
@@ -66,16 +66,61 @@ use crate::utils::{fields, marker};
 ///
 /// Combines all mapper generations into a single `TokenStream`.
 pub fn generate(entity: &EntityDef) -> TokenStream {
+    let embed_checks = generate_embed_drift_checks(entity);
+
     let row_to_entity = generate_row_to_entity(entity);
     let entity_to_insertable = generate_entity_to_insertable(entity);
     let entity_to_response = generate_entity_to_response(entity);
     let create_to_entity = generate_create_to_entity(entity);
 
     quote! {
+        #embed_checks
         #row_to_entity
         #entity_to_insertable
         #entity_to_response
         #create_to_entity
+    }
+}
+
+/// Compile-time shape checks for `#[embed(...)]` declarations.
+///
+/// Destructures each embedded struct against the declared subfields:
+/// a missing, extra, renamed or retyped field in the real struct fails
+/// the build instead of silently corrupting the column mapping.
+fn generate_embed_drift_checks(entity: &EntityDef) -> TokenStream {
+    let checks: Vec<TokenStream> = entity
+        .embed_parents()
+        .iter()
+        .map(|field| {
+            let ty = &field.ty;
+            let embed = field
+                .embed
+                .as_ref()
+                .expect("embed_parents returns only embed fields");
+            let names: Vec<&syn::Ident> = embed.subfields.iter().map(|(n, _)| n).collect();
+            let bindings: Vec<TokenStream> = embed
+                .subfields
+                .iter()
+                .map(|(n, t)| quote! { let _: #t = #n; })
+                .collect();
+            quote! {
+                #[allow(dead_code)]
+                fn __assert_embed_shape(value: #ty) {
+                    let #ty { #(#names),* } = value;
+                    #(#bindings)*
+                }
+            }
+        })
+        .collect();
+
+    if checks.is_empty() {
+        return TokenStream::new();
+    }
+
+    quote! {
+        const _: () = {
+            #(#checks)*
+        };
     }
 }
 
@@ -174,5 +219,95 @@ fn generate_create_to_entity(entity: &EntityDef) -> TokenStream {
                 Self { #(#assigns),* }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod embed_tests {
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn embedded_entity() -> EntityDef {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "products")]
+            pub struct Product {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                #[embed(prefix = "price_", fields(amount_cents: i64, currency: String))]
+                pub price: Money,
+                #[field(create, response)]
+                pub name: String,
+            }
+        };
+        EntityDef::from_derive_input(&input).unwrap()
+    }
+
+    #[test]
+    fn synthetic_columns_expand_after_parent() {
+        let entity = embedded_entity();
+        let names: Vec<String> = entity
+            .column_fields()
+            .iter()
+            .map(|f| f.name_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["id", "price_amount_cents", "price_currency", "name"]
+        );
+    }
+
+    #[test]
+    fn row_to_entity_reconstructs_parent() {
+        let code = generate(&embedded_entity()).to_string();
+        assert!(code.contains("price : Money"));
+        assert!(code.contains("amount_cents : row . price_amount_cents"));
+        assert!(code.contains("currency : row . price_currency"));
+    }
+
+    #[test]
+    fn entity_to_insertable_flattens_parent() {
+        let code = generate(&embedded_entity()).to_string();
+        assert!(code.contains("price_amount_cents : entity . price . amount_cents . clone ()"));
+    }
+
+    #[test]
+    fn drift_check_destructures_declared_shape() {
+        let code = generate(&embedded_entity()).to_string();
+        assert!(code.contains("__assert_embed_shape"));
+        assert!(code.contains("let Money { amount_cents , currency }"));
+    }
+
+    #[test]
+    fn embed_column_collision_rejected() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "products")]
+            pub struct Product {
+                #[id]
+                pub id: uuid::Uuid,
+                #[embed(prefix = "", fields(name: String))]
+                pub price: Money,
+                #[field(create, response)]
+                pub name: String,
+            }
+        };
+        let err = EntityDef::from_derive_input(&input).unwrap_err();
+        assert!(err.to_string().contains("collides"));
+    }
+
+    #[test]
+    fn embed_option_parent_rejected() {
+        let input: DeriveInput = syn::parse_quote! {
+            #[entity(table = "products")]
+            pub struct Product {
+                #[id]
+                pub id: uuid::Uuid,
+                #[embed(prefix = "price_", fields(amount: i64))]
+                pub price: Option<Money>,
+            }
+        };
+        let err = EntityDef::from_derive_input(&input).unwrap_err();
+        assert!(err.to_string().contains("Option"));
     }
 }

--- a/crates/entity-derive-impl/src/entity/migrations/postgres/ddl.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres/ddl.rs
@@ -25,7 +25,7 @@ pub fn generate_up(entity: &EntityDef) -> String {
     sql.push_str(&generate_create_table(entity));
 
     // Single-column indexes
-    for field in entity.all_fields() {
+    for field in entity.column_fields() {
         if field.column().has_index() {
             sql.push_str(&generate_single_index(entity, field));
         }
@@ -53,8 +53,8 @@ fn generate_create_table(entity: &EntityDef) -> String {
     let full_table = entity.full_table_name();
 
     let columns: Vec<String> = entity
-        .all_fields()
-        .iter()
+        .column_fields()
+        .into_iter()
         .map(|f| generate_column_def(f, &mapper, entity))
         .collect();
 

--- a/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/accessors.rs
@@ -123,6 +123,22 @@ impl EntityDef {
         self.fields.iter().find(|f| f.storage.is_owner)
     }
 
+    /// Get all database-column fields.
+    ///
+    /// Equals [`Self::all_fields`] minus `#[embed]` parents: parents
+    /// live on the entity struct only, their synthetic prefixed
+    /// subfields are the actual columns.
+    #[must_use]
+    pub fn column_fields(&self) -> Vec<&FieldDef> {
+        self.fields.iter().filter(|f| f.embed.is_none()).collect()
+    }
+
+    /// Get all `#[embed]` parent fields.
+    #[must_use]
+    pub fn embed_parents(&self) -> Vec<&FieldDef> {
+        self.fields.iter().filter(|f| f.embed.is_some()).collect()
+    }
+
     pub fn all_fields(&self) -> &[FieldDef] {
         &self.fields
     }

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -158,6 +158,8 @@ impl EntityDef {
             .with_span(&input.ident));
         }
 
+        expand_embed_fields(&mut fields)?;
+
         let version_fields: Vec<usize> = fields
             .iter()
             .enumerate()
@@ -264,6 +266,75 @@ impl EntityDef {
             typed_constraints: attrs.typed_constraints
         })
     }
+}
+
+/// Expand `#[embed(...)]` parents into synthetic prefixed column fields.
+///
+/// Each declared subfield becomes a `FieldDef` named
+/// `{prefix}{subfield}` inserted right after its parent. Synthetic
+/// fields carry no DTO exposure — they exist purely for the database
+/// layer (Row struct, DDL, CRUD SQL) — and remember their origin for
+/// the generated mapping code.
+fn expand_embed_fields(fields: &mut Vec<FieldDef>) -> darling::Result<()> {
+    let mut existing: std::collections::HashSet<String> = fields
+        .iter()
+        .map(super::super::field::FieldDef::name_str)
+        .collect();
+
+    let mut insertions: Vec<(usize, Vec<FieldDef>)> = Vec::new();
+    for (idx, field) in fields.iter().enumerate() {
+        let Some(embed) = &field.embed else {
+            continue;
+        };
+
+        if matches!(
+            &field.ty,
+            syn::Type::Path(tp) if tp
+                .path
+                .segments
+                .last()
+                .is_some_and(|s| s.ident == "Option")
+        ) {
+            return Err(
+                darling::Error::custom("#[embed] does not support Option<T> parents yet")
+                    .with_span(&field.ident)
+            );
+        }
+
+        let mut synthetic = Vec::new();
+        for (sub, ty) in &embed.subfields {
+            let column = format!("{}{}", embed.prefix, sub);
+            if !existing.insert(column.clone()) {
+                return Err(darling::Error::custom(format!(
+                    "embed column `{column}` collides with an existing column"
+                ))
+                .with_span(&field.ident));
+            }
+            synthetic.push(FieldDef {
+                ident:        syn::Ident::new(&column, field.ident.span()),
+                ty:           ty.clone(),
+                sortable:     false,
+                embed:        None,
+                embed_origin: Some((field.ident.clone(), sub.clone())),
+                expose:       Default::default(),
+                storage:      Default::default(),
+                filter:       Default::default(),
+                column:       Default::default(),
+                doc:          None,
+                validation:   Default::default(),
+                example:      None,
+                map:          Default::default()
+            });
+        }
+        insertions.push((idx + 1, synthetic));
+    }
+
+    for (at, synthetic) in insertions.into_iter().rev() {
+        for (offset, field) in synthetic.into_iter().enumerate() {
+            fields.insert(at + offset, field);
+        }
+    }
+    Ok(())
 }
 
 /// Validate `#[entity(upsert(...))]` configuration at parse time.

--- a/crates/entity-derive-impl/src/entity/parse/field.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field.rs
@@ -94,6 +94,67 @@ fn parse_belongs_to(attr: &Attribute) -> (Option<Ident>, Option<ReferentialActio
 /// #[column(unique, index)]           // ColumnConfig
 /// pub email: String,
 /// ```
+/// Embedded value-object declaration parsed from
+/// `#[embed(prefix = "price_", fields(amount_cents: i64, currency: String))]`.
+#[derive(Debug, Clone)]
+pub struct EmbedConfig {
+    /// Column-name prefix for the flattened subfields.
+    pub prefix: String,
+
+    /// Declared subfields of the embedded struct.
+    pub subfields: Vec<(Ident, Type)>
+}
+
+impl EmbedConfig {
+    /// Parse an `#[embed(...)]` attribute.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `fields(...)` is missing/empty, an option
+    /// is unknown, or the syntax does not match `name: Type` pairs.
+    pub fn from_attr(attr: &syn::Attribute) -> darling::Result<Self> {
+        let mut prefix: Option<String> = None;
+        let mut subfields: Vec<(Ident, Type)> = Vec::new();
+
+        attr.parse_nested_meta(|meta| {
+            if meta.path.is_ident("prefix") {
+                let value: syn::LitStr = meta.value()?.parse()?;
+                prefix = Some(value.value());
+            } else if meta.path.is_ident("fields") {
+                let content;
+                syn::parenthesized!(content in meta.input);
+                while !content.is_empty() {
+                    let name: Ident = content.parse()?;
+                    let _: syn::Token![:] = content.parse()?;
+                    let ty: Type = content.parse()?;
+                    subfields.push((name, ty));
+                    if content.peek(syn::Token![,]) {
+                        let _: syn::Token![,] = content.parse()?;
+                    }
+                }
+            } else {
+                return Err(meta.error(
+                    "unknown embed option; expected prefix = \"...\" and fields(name: Type, ...)"
+                ));
+            }
+            Ok(())
+        })
+        .map_err(darling::Error::from)?;
+
+        if subfields.is_empty() {
+            return Err(darling::Error::custom(
+                "embed requires fields(name: Type, ...) with at least one subfield"
+            )
+            .with_span(attr));
+        }
+
+        Ok(Self {
+            prefix: prefix.unwrap_or_default(),
+            subfields
+        })
+    }
+}
+
 #[derive(Debug)]
 pub struct FieldDef {
     /// Field identifier (e.g., `id`, `name`, `created_at`).
@@ -102,10 +163,22 @@ pub struct FieldDef {
     /// Field type (e.g., `Uuid`, `Option<String>`, `DateTime<Utc>`).
     pub ty: Type,
 
-    /// DTO exposure configuration.
     /// Whether the field is marked `#[sort]` (dynamic ORDER BY).
     pub sortable: bool,
 
+    /// Embedded value-object configuration from `#[embed(...)]`.
+    ///
+    /// `Some` marks an embed parent: the field lives on the entity as
+    /// a struct but maps to several prefixed columns.
+    pub embed: Option<EmbedConfig>,
+
+    /// Synthetic embed column origin.
+    ///
+    /// `Some((parent, subfield))` marks a generated column field that
+    /// flattens `parent.subfield`. Such fields never appear in DTOs.
+    pub embed_origin: Option<(Ident, Ident)>,
+
+    /// DTO exposure configuration.
     pub expose: ExposeConfig,
 
     /// Database storage configuration.
@@ -163,6 +236,7 @@ impl FieldDef {
         let example = example::parse_example_attr(&field.attrs);
 
         let mut sortable = false;
+        let mut embed: Option<EmbedConfig> = None;
         let mut expose = ExposeConfig::default();
         let mut storage = StorageConfig::default();
         let mut filter = FilterConfig::default();
@@ -180,6 +254,8 @@ impl FieldDef {
                 sortable = true;
             } else if attr.path().is_ident("version") {
                 storage.is_version = true;
+            } else if attr.path().is_ident("embed") {
+                embed = Some(EmbedConfig::from_attr(attr)?);
             } else if attr.path().is_ident("field") {
                 expose = ExposeConfig::from_attr(attr);
             } else if attr.path().is_ident("belongs_to") {
@@ -201,6 +277,8 @@ impl FieldDef {
             ident,
             ty,
             sortable,
+            embed,
+            embed_origin: None,
             expose,
             storage,
             filter,

--- a/crates/entity-derive-impl/src/entity/row.rs
+++ b/crates/entity-derive-impl/src/entity/row.rs
@@ -63,11 +63,15 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     let vis = &entity.vis;
     let row_name = entity.ident_with("", "Row");
-    let field_defs = entity.all_fields().iter().map(|f| {
-        let name = f.name();
-        let ty = f.ty();
-        quote! { pub #name: #ty }
-    });
+    let field_defs = entity
+        .all_fields()
+        .iter()
+        .filter(|f| f.embed.is_none())
+        .map(|f| {
+            let name = f.name();
+            let ty = f.ty();
+            quote! { pub #name: #ty }
+        });
 
     let marker = marker::generated();
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres/context.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/context.rs
@@ -87,7 +87,7 @@ impl<'a> Context<'a> {
     /// Create a new generation context from an entity definition.
     pub fn new(entity: &'a EntityDef) -> Self {
         let id_field = entity.id_field();
-        let fields = entity.all_fields();
+        let fields = entity.column_fields();
         let dialect = entity.dialect;
 
         Self {
@@ -102,7 +102,7 @@ impl<'a> Context<'a> {
             table: entity.full_table_name(),
             id_name: id_field.name(),
             id_type: id_field.ty(),
-            columns_str: join_columns(fields),
+            columns_str: join_columns(&fields),
             placeholders_str: dialect.placeholders(fields.len()),
             soft_delete: entity.is_soft_delete(),
             returning: entity.returning.clone(),

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -361,10 +361,10 @@ mod tests {
 
     #[test]
     fn join_columns_multiple() {
-        let fields = vec![
+        let fields = [
             parse_field(quote! { pub id: Uuid }),
             parse_field(quote! { pub name: String }),
-            parse_field(quote! { pub email: String }),
+            parse_field(quote! { pub email: String })
         ];
         let refs: Vec<&FieldDef> = fields.iter().collect();
         let result = join_columns(&refs);

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -24,9 +24,10 @@ use crate::entity::parse::{FieldDef, FilterType};
 /// ```text
 /// ["id", "name", "email"] -> "id, name, email"
 /// ```
-pub fn join_columns(fields: &[FieldDef]) -> String {
+pub fn join_columns(fields: &[&FieldDef]) -> String {
     fields
         .iter()
+        .copied()
         .map(crate::entity::parse::FieldDef::name_str)
         .collect::<Vec<_>>()
         .join(", ")
@@ -44,6 +45,7 @@ pub fn join_columns(fields: &[FieldDef]) -> String {
 pub fn insert_bindings(fields: &[FieldDef]) -> Vec<TokenStream> {
     fields
         .iter()
+        .filter(|f| f.embed.is_none())
         .map(|f| {
             let name = f.name();
             quote! { .bind(insertable.#name) }
@@ -220,6 +222,24 @@ pub fn dynamic_set_stmts(fields: &[&FieldDef]) -> TokenStream {
             let column = f.name_str();
             let assignment = format!("{column} = ${{}}");
             let null_assignment = format!("{column} = NULL");
+            if let Some(embed) = &f.embed {
+                let pushes: Vec<TokenStream> = embed
+                    .subfields
+                    .iter()
+                    .map(|(sub, _)| {
+                        let col = format!("{}{} = ${{}}", embed.prefix, sub);
+                        quote! {
+                            __sets.push(format!(#col, __idx));
+                            __idx += 1;
+                        }
+                    })
+                    .collect();
+                return quote! {
+                    if dto.#name.is_some() {
+                        #(#pushes)*
+                    }
+                };
+            }
             if f.is_option() {
                 quote! {
                     match &dto.#name {
@@ -289,6 +309,18 @@ pub fn dynamic_set_binds(fields: &[&FieldDef]) -> TokenStream {
         .iter()
         .map(|f| {
             let name = f.name();
+            if let Some(embed) = &f.embed {
+                let binds: Vec<TokenStream> = embed
+                    .subfields
+                    .iter()
+                    .map(|(sub, _)| quote! { q = q.bind(__v.#sub.clone()); })
+                    .collect();
+                return quote! {
+                    if let Some(__v) = dto.#name {
+                        #(#binds)*
+                    }
+                };
+            }
             if f.is_option() {
                 quote! {
                     if let Some(Some(__v)) = dto.#name {
@@ -323,7 +355,7 @@ mod tests {
     #[test]
     fn join_columns_single() {
         let field = parse_field(quote! { pub name: String });
-        let result = join_columns(&[field]);
+        let result = join_columns(&[&field]);
         assert_eq!(result, "name");
     }
 
@@ -334,7 +366,8 @@ mod tests {
             parse_field(quote! { pub name: String }),
             parse_field(quote! { pub email: String }),
         ];
-        let result = join_columns(&fields);
+        let refs: Vec<&FieldDef> = fields.iter().collect();
+        let result = join_columns(&refs);
         assert_eq!(result, "id, name, email");
     }
 

--- a/crates/entity-derive-impl/src/entity/sql/postgres/upsert.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/upsert.rs
@@ -129,8 +129,8 @@ impl Context<'_> {
             UpsertAction::Update => {
                 let assignments: Vec<String> = self
                     .entity
-                    .all_fields()
-                    .iter()
+                    .column_fields()
+                    .into_iter()
                     .filter(|f| {
                         let col = f.name_str();
                         !FieldDef::is_id(f) && !conflict.contains(&col)

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -469,8 +469,8 @@ use proc_macro::TokenStream;
 #[proc_macro_derive(
     Entity,
     attributes(
-        entity, field, id, auto, owner, sort, version, validate, belongs_to, has_many, projection,
-        filter, command, example, column, map
+        entity, field, id, auto, owner, sort, version, embed, validate, belongs_to, has_many,
+        projection, filter, command, example, column, map
     )
 )]
 pub fn derive_entity(input: TokenStream) -> TokenStream {

--- a/crates/entity-derive-impl/src/utils/fields.rs
+++ b/crates/entity-derive-impl/src/utils/fields.rs
@@ -45,8 +45,12 @@ pub fn assigns(fields: &[FieldDef], source: &str) -> Vec<TokenStream> {
     let src = Ident::new(source, Span::call_site());
     fields
         .iter()
+        .filter(|f| f.embed.is_none())
         .map(|f: &FieldDef| {
             let name = f.name();
+            if let Some((parent, sub)) = &f.embed_origin {
+                return quote! { #name: #src.#parent.#sub.clone() };
+            }
             quote! { #name: #src.#name }
         })
         .collect()
@@ -59,8 +63,12 @@ pub fn assigns_clone(fields: &[FieldDef], source: &str) -> Vec<TokenStream> {
     let src = Ident::new(source, Span::call_site());
     fields
         .iter()
+        .filter(|f| f.embed.is_none())
         .map(|f: &FieldDef| {
             let name = f.name();
+            if let Some((parent, sub)) = &f.embed_origin {
+                return quote! { #name: #src.#parent.#sub.clone() };
+            }
             quote! { #name: #src.#name.clone() }
         })
         .collect()
@@ -109,6 +117,7 @@ pub fn create_assigns(
 ) -> Vec<TokenStream> {
     all_fields
         .iter()
+        .filter(|f| f.embed_origin.is_none())
         .map(|f: &FieldDef| {
             let name = f.name();
             let is_in_create = create_fields.iter().any(|cf: &&FieldDef| cf.name() == name);
@@ -152,19 +161,31 @@ pub fn create_assigns(
 /// ```
 pub fn row_assigns(fields: &[FieldDef], source: &str) -> Vec<TokenStream> {
     let src = Ident::new(source, Span::call_site());
-    fields
-        .iter()
-        .map(|f: &FieldDef| {
+    let mut assigns: Vec<TokenStream> = Vec::new();
+    for f in fields {
+        if f.embed_origin.is_some() {
+            continue;
+        }
+        if let Some(embed) = &f.embed {
             let name = f.name();
-            let map = f.map();
-            if matches!(map, MapConfig::None) {
-                quote! { #name: #src.#name }
-            } else {
-                let expr = map.generate(name, &src);
-                quote! { #name: #expr }
-            }
-        })
-        .collect()
+            let ty = &f.ty;
+            let sub_assigns = embed.subfields.iter().map(|(sub, _)| {
+                let column = Ident::new(&format!("{}{}", embed.prefix, sub), Span::call_site());
+                quote! { #sub: #src.#column }
+            });
+            assigns.push(quote! { #name: #ty { #(#sub_assigns),* } });
+            continue;
+        }
+        let name = f.name();
+        let map = f.map();
+        if matches!(map, MapConfig::None) {
+            assigns.push(quote! { #name: #src.#name });
+        } else {
+            let expr = map.generate(name, &src);
+            assigns.push(quote! { #name: #expr });
+        }
+    }
+    assigns
 }
 
 #[cfg(test)]

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.21.0"
+version = "0.22.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -75,7 +75,7 @@ tracing = ["entity-core/tracing"]
 
 [dependencies]
 entity-core = { path = "../entity-core", version = "0.10", features = ["serde"] }
-entity-derive-impl = { path = "../entity-derive-impl", version = "0.19", default-features = false }
+entity-derive-impl = { path = "../entity-derive-impl", version = "0.20", default-features = false }
 
 [dev-dependencies]
 trybuild = "1"

--- a/crates/entity-derive/tests/cases/fail/embed_shape_mismatch.rs
+++ b/crates/entity-derive/tests/cases/fail/embed_shape_mismatch.rs
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+pub struct Money {
+    pub amount_cents: i64,
+    pub currency: String,
+    pub precision: u8,
+}
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "products")]
+pub struct Product {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[embed(prefix = "price_", fields(amount_cents: i64, currency: String))]
+    pub price: Money,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/embed_shape_mismatch.stderr
+++ b/crates/entity-derive/tests/cases/fail/embed_shape_mismatch.stderr
@@ -1,0 +1,17 @@
+error: pattern requires `..` due to inaccessible fields
+  --> tests/cases/fail/embed_shape_mismatch.rs:14:24
+   |
+14 | #[derive(Debug, Clone, Entity)]
+   |                        ^^^^^^
+   |
+   = note: this error originates in the derive macro `Entity` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: ignore the inaccessible and unused fields
+   |
+21 |     #[embed(prefix = "price_", fields(amount_cents: i64, currency, ..: String))]
+   |                                                                  ++++
+
+error[E0063]: missing field `precision` in initializer of `Money`
+  --> tests/cases/fail/embed_shape_mismatch.rs:22:16
+   |
+22 |     pub price: Money,
+   |                ^^^^^ missing `precision`

--- a/crates/entity-derive/tests/cases/pass/embed_value_object.rs
+++ b/crates/entity-derive/tests/cases/pass/embed_value_object.rs
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, PartialEq, utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+pub struct Money {
+    pub amount_cents: i64,
+    pub currency: String,
+}
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "products", migrations)]
+pub struct Product {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[embed(prefix = "price_", fields(amount_cents: i64, currency: String))]
+    pub price: Money,
+
+    #[field(create, response)]
+    pub name: String,
+}
+
+async fn exercise(pool: sqlx::PgPool) -> Result<(), sqlx::Error> {
+    let created: Product = pool
+        .create(CreateProductRequest {
+            price: Money {
+                amount_cents: 1999,
+                currency: "USD".into(),
+            },
+            name: "Widget".into(),
+        })
+        .await?;
+    assert_eq!(created.price.amount_cents, 1999);
+    Ok(())
+}
+
+fn main() {
+    assert!(Product::MIGRATION_UP.contains("price_amount_cents BIGINT NOT NULL"));
+    assert!(Product::MIGRATION_UP.contains("price_currency TEXT NOT NULL"));
+    assert!(!Product::MIGRATION_UP.contains(" price "));
+    let _ = exercise;
+}


### PR DESCRIPTION
Closes #151.

Value objects stay real structs on the entity while storing as flat scalar columns.

## `#[embed(prefix = "...", fields(name: Ty, ...))]`

- Declared subfields expand into synthetic prefixed column fields at parse time; DDL, Row struct, Insertable, CRUD SQL, dynamic PATCH updates and upsert all operate on the flattened columns
- DTOs and the entity carry the struct itself (`Money` in, `Money` out); Row→Entity reconstructs via struct literal, Entity→Insertable flattens per subfield
- Drift protection: the declared shape is destructured against the real struct in a generated `const` — renamed/retyped/missing/extra fields fail the build (see the pinned fail case)
- Validations: non-empty `fields(...)`, column-name collisions rejected, `Option<T>` parents rejected (deferred; noted in issue)
- Design deviation from the issue recorded in issue comment: a companion derive cannot pass field metadata between proc macros, so the attribute declares the shape explicitly with a compile-time cross-check

## Testing

- 6 new unit tests (expansion order, reconstruction, flatten, drift check, collision, Option rejection) — 671 total green
- trybuild: pass case incl. DDL assertions and CRUD usage; fail case pinned to the drift error
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs & versions

- README: field quick-reference + "Embedded Value Objects" section + features table, pins 0.22
- entity-derive 0.21.0 → 0.22.0, entity-derive-impl 0.19.0 → 0.20.0
- Wiki follows after merge