### PR TITLE
157

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ entity-derive = { version = "0.22", features = ["postgres", "api"] }
 | `outbox` |   | Transactional-outbox enqueue in generated writes + `OutboxDrainer` runtime (pulls in `events`) |
 | `api` |   | Generate HTTP handlers (`axum`) and `utoipa` OpenAPI schemas |
 | `validate` |   | Wire up `validator::Validate` on generated DTOs |
+| `garde` |   | Maintained alternative: `garde::Validate` with translated `#[validate(...)]` rules (`validate` wins if both are on) |
 | `tracing` |   | Wrap every generated async method in `#[tracing::instrument]` carrying `entity` + `op` span fields |
 
 Default features cover the full entity-attribute surface so existing projects work without changes. For lean builds, opt out of what you don't need:
@@ -600,6 +601,17 @@ Need conditional commit/rollback inside the closure? Use
 [`run_with_commit`](https://docs.rs/entity-core/latest/entity_core/transaction/struct.Transaction.html#method.run_with_commit)
 — it takes `TransactionContext` by value so the closure can call
 `ctx.commit().await` (or `ctx.rollback().await`) itself.
+
+### Validation Backends
+
+`#[validate(...)]` constraints on entity fields translate to the chosen
+backend. `validate` derives `validator::Validate` (unchanged). The new
+`garde` feature derives `garde::Validate` instead, translating
+`length`/`range`/`email`/`url`/`pattern` rules (Option-wrapped DTO
+fields validate the inner value; unconstrained fields get
+`garde(skip)`). `validator_derive` depends on the unmaintained
+`proc-macro-error2` (RUSTSEC-2026-0173) — `garde` avoids it. When both
+features are enabled, `validate` takes precedence.
 
 ### Tracing
 

--- a/crates/entity-derive-impl/src/entity/dto.rs
+++ b/crates/entity-derive-impl/src/entity/dto.rs
@@ -39,7 +39,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::parse::EntityDef;
+use super::parse::{EntityDef, FieldDef};
 use crate::utils::marker;
 
 /// Generates all DTO structs for the entity.
@@ -65,7 +65,11 @@ fn generate_create_dto(entity: &EntityDef) -> TokenStream {
     let field_defs = fields.iter().map(|f| {
         let n = f.name();
         let t = f.ty();
-        quote! { pub #n: #t }
+        let garde = garde_attr(f, 0);
+        quote! {
+            #garde
+            pub #n: #t
+        }
     });
 
     let marker = marker::generated();
@@ -75,8 +79,56 @@ fn generate_create_dto(entity: &EntityDef) -> TokenStream {
         #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
         #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
         #[cfg_attr(feature = "validate", derive(validator::Validate))]
+        #[cfg_attr(all(feature = "garde", not(feature = "validate")), derive(garde::Validate))]
         #vis struct #name { #(#field_defs),* }
     }
+}
+
+/// Build the `#[garde(...)]` attribute for a DTO field.
+///
+/// Translates the typed validation constraints into garde rules;
+/// fields without constraints get `#[garde(skip)]` (garde requires an
+/// annotation on every field). `option_depth` wraps the rules in
+/// `inner(...)` per `Option` layer so Update DTO wrappers validate the
+/// contained value.
+fn garde_attr(field: &FieldDef, option_depth: usize) -> TokenStream {
+    let v = &field.validation;
+    let mut rules: Vec<String> = Vec::new();
+
+    match (v.min_length, v.max_length) {
+        (Some(min), Some(max)) => rules.push(format!("length(min = {min}, max = {max})")),
+        (Some(min), None) => rules.push(format!("length(min = {min})")),
+        (None, Some(max)) => rules.push(format!("length(max = {max})")),
+        (None, None) => {}
+    }
+    match (v.minimum, v.maximum) {
+        (Some(min), Some(max)) => rules.push(format!("range(min = {min}, max = {max})")),
+        (Some(min), None) => rules.push(format!("range(min = {min})")),
+        (None, Some(max)) => rules.push(format!("range(max = {max})")),
+        (None, None) => {}
+    }
+    if v.email {
+        rules.push("email".to_string());
+    }
+    if v.url {
+        rules.push("url".to_string());
+    }
+    if let Some(pattern) = &v.pattern {
+        rules.push(format!("pattern(\"{pattern}\")"));
+    }
+
+    let body = if rules.is_empty() {
+        "skip".to_string()
+    } else {
+        let mut inner = rules.join(", ");
+        for _ in 0..option_depth {
+            inner = format!("inner({inner})");
+        }
+        inner
+    };
+
+    let tokens: TokenStream = body.parse().expect("garde rules are valid tokens");
+    quote! { #[cfg_attr(all(feature = "garde", not(feature = "validate")), garde(#tokens))] }
 }
 
 fn generate_update_dto(entity: &EntityDef) -> TokenStream {
@@ -91,16 +143,22 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
         let n = f.name();
         let t = f.ty();
         if f.is_option() {
+            let garde = garde_attr(f, 2);
             quote! {
                 #[serde(
                     default,
                     skip_serializing_if = "Option::is_none",
                     with = "::entity_core::serde_helpers::double_option"
                 )]
+                #garde
                 pub #n: Option<#t>
             }
         } else {
-            quote! { pub #n: Option<#t> }
+            let garde = garde_attr(f, 1);
+            quote! {
+                #garde
+                pub #n: Option<#t>
+            }
         }
     });
 
@@ -111,6 +169,7 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
             ///
             /// The UPDATE only applies when the row still carries this
             /// version; on mismatch the call fails with a conflict.
+            #[cfg_attr(all(feature = "garde", not(feature = "validate")), garde(skip))]
             pub expected_version: #vt,
         }
     });
@@ -122,10 +181,12 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
         #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
         #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
         #[cfg_attr(feature = "validate", derive(validator::Validate))]
+        #[cfg_attr(all(feature = "garde", not(feature = "validate")), derive(garde::Validate))]
         #vis struct #name {
             #(#field_defs,)*
             #version_field
         }
+
     }
 }
 
@@ -150,5 +211,62 @@ fn generate_response_dto(entity: &EntityDef) -> TokenStream {
         #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
         #[cfg_attr(feature = "api", derive(utoipa::ToSchema))]
         #vis struct #name { #(#field_defs),* }
+    }
+}
+
+#[cfg(test)]
+mod garde_tests {
+    use quote::quote;
+    use syn::DeriveInput;
+
+    use super::*;
+
+    fn parse_entity(tokens: proc_macro2::TokenStream) -> EntityDef {
+        let input: DeriveInput = syn::parse2(tokens).expect("test entity must parse");
+        EntityDef::from_derive_input(&input).expect("test entity must be valid")
+    }
+
+    fn validated_entity() -> EntityDef {
+        parse_entity(quote! {
+            #[entity(table = "users")]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, update, response)]
+                #[validate(length(min = 1, max = 64))]
+                pub name: String,
+                #[field(create, response)]
+                #[validate(email)]
+                pub email: String,
+                #[field(create, update, response)]
+                pub bio: Option<String>,
+            }
+        })
+    }
+
+    #[test]
+    fn create_dto_translates_constraints() {
+        let code = generate(&validated_entity()).to_string();
+        assert!(code.contains("garde (length (min = 1 , max = 64))"));
+        assert!(code.contains("garde (email)"));
+        assert!(code.contains("derive (garde :: Validate)"));
+    }
+
+    #[test]
+    fn unconstrained_fields_get_skip() {
+        let code = generate(&validated_entity()).to_string();
+        assert!(code.contains("garde (skip)"));
+    }
+
+    #[test]
+    fn update_dto_wraps_rules_in_inner() {
+        let code = generate(&validated_entity()).to_string();
+        assert!(code.contains("inner (length (min = 1 , max = 64))"));
+    }
+
+    #[test]
+    fn validate_takes_precedence_when_both_enabled() {
+        let code = generate(&validated_entity()).to_string();
+        assert!(code.contains("all (feature = \"garde\" , not (feature = \"validate\"))"));
     }
 }

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -45,6 +45,8 @@ api = []
 
 # `validator::Validate` integration on DTOs.
 validate = []
+# `garde::Validate` integration on DTOs (mutually exclusive with `validate`).
+garde = []
 
 # Lifecycle event types (`{Entity}Event::Created` / `Updated` / etc.).
 events = ["entity-derive-impl/events"]
@@ -96,6 +98,7 @@ tracing = "0.1"
 utoipa = { version = "5", features = ["chrono", "uuid"] }
 validator = { version = "0.20", features = ["derive"] }
 axum = "0.8"
+garde = { version = "0.23", features = ["derive", "email", "url"] }
 masterror = { version = "0.27", features = ["axum", "openapi"] }
 
 [package.metadata.docs.rs]

--- a/crates/entity-derive/tests/garde.rs
+++ b/crates/entity-derive/tests/garde.rs
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Behavior tests for the `garde` validation backend.
+//!
+//! Run with `--features garde` (and without `validate`, which takes
+//! precedence when both are enabled).
+
+#![cfg(all(feature = "garde", not(feature = "validate")))]
+
+use entity_derive::Entity;
+use garde::Validate;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Entity)]
+#[entity(table = "users")]
+pub struct User {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[validate(length(min = 3, max = 8))]
+    pub name: String,
+
+    #[field(create, response)]
+    #[validate(email)]
+    pub email: String
+}
+
+#[test]
+fn valid_create_dto_passes() {
+    let dto = CreateUserRequest {
+        name:  "alice".into(),
+        email: "alice@example.com".into()
+    };
+    assert!(dto.validate().is_ok());
+}
+
+#[test]
+fn short_name_fails_length_rule() {
+    let dto = CreateUserRequest {
+        name:  "al".into(),
+        email: "alice@example.com".into()
+    };
+    assert!(dto.validate().is_err());
+}
+
+#[test]
+fn bad_email_fails() {
+    let dto = CreateUserRequest {
+        name:  "alice".into(),
+        email: "not-an-email".into()
+    };
+    assert!(dto.validate().is_err());
+}
+
+#[test]
+fn update_dto_validates_inner_value() {
+    let ok = UpdateUserRequest {
+        name: Some("alice".into())
+    };
+    assert!(ok.validate().is_ok());
+
+    let bad = UpdateUserRequest {
+        name: Some("al".into())
+    };
+    assert!(bad.validate().is_err());
+
+    let absent = UpdateUserRequest {
+        name: None
+    };
+    assert!(absent.validate().is_ok());
+}

--- a/wiki/Atributos.md
+++ b/wiki/Atributos.md
@@ -711,3 +711,16 @@ pub struct Product {
     pub price: Money,
 }
 ```
+
+### Feature `garde` (backend de validación)
+
+Habilita `garde::Validate` en los DTO generados como alternativa mantenida a `validator`. Las reglas `#[validate(...)]` (`length`, `range`, `email`, `url`, `pattern`) se traducen a sintaxis garde; los campos sin restricciones reciben `garde(skip)`; los campos Option del DTO de actualización validan el valor interno con `inner(...)`. Con ambas features activas, `validate` tiene prioridad.
+
+```rust
+#[field(create, update, response)]
+#[validate(length(min = 3, max = 8))]
+pub name: String,
+
+let dto: CreateUserRequest = serde_json::from_str(body)?;
+garde::Validate::validate(&dto)?;
+```

--- a/wiki/Attributes-en.md
+++ b/wiki/Attributes-en.md
@@ -771,3 +771,16 @@ pub struct Product {
     pub price: Money,
 }
 ```
+
+### `garde` feature (validation backend)
+
+Enables `garde::Validate` on generated DTOs as a maintained alternative to `validator`. Field `#[validate(...)]` rules (`length`, `range`, `email`, `url`, `pattern`) are translated to garde syntax; unconstrained fields get `garde(skip)`; Option-wrapped Update DTO fields validate the inner value via `inner(...)`. When both `validate` and `garde` are enabled, `validate` takes precedence.
+
+```rust
+#[field(create, update, response)]
+#[validate(length(min = 3, max = 8))]
+pub name: String,
+
+let dto: CreateUserRequest = serde_json::from_str(body)?;
+garde::Validate::validate(&dto)?;
+```

--- a/wiki/Атрибуты.md
+++ b/wiki/Атрибуты.md
@@ -771,3 +771,16 @@ pub struct Product {
     pub price: Money,
 }
 ```
+
+### Фича `garde` (бэкенд валидации)
+
+Включает `garde::Validate` на генерируемых DTO как поддерживаемую альтернативу `validator`. Правила `#[validate(...)]` (`length`, `range`, `email`, `url`, `pattern`) транслируются в синтаксис garde; поля без ограничений получают `garde(skip)`; Option-обёртки Update DTO валидируют внутреннее значение через `inner(...)`. При включении обеих фич приоритет у `validate`.
+
+```rust
+#[field(create, update, response)]
+#[validate(length(min = 3, max = 8))]
+pub name: String,
+
+let dto: CreateUserRequest = serde_json::from_str(body)?;
+garde::Validate::validate(&dto)?;
+```

--- a/wiki/属性.md
+++ b/wiki/属性.md
@@ -711,3 +711,16 @@ pub struct Product {
     pub price: Money,
 }
 ```
+
+### `garde` 特性（验证后端）
+
+在生成的 DTO 上启用 `garde::Validate`，作为 `validator` 的持续维护替代。字段的 `#[validate(...)]` 规则（`length`、`range`、`email`、`url`、`pattern`）会翻译为 garde 语法；无约束字段获得 `garde(skip)`；更新 DTO 的 Option 包装通过 `inner(...)` 验证内部值。两个特性同时启用时，`validate` 优先。
+
+```rust
+#[field(create, update, response)]
+#[validate(length(min = 3, max = 8))]
+pub name: String,
+
+let dto: CreateUserRequest = serde_json::from_str(body)?;
+garde::Validate::validate(&dto)?;
+```

--- a/wiki/속성.md
+++ b/wiki/속성.md
@@ -711,3 +711,16 @@ pub struct Product {
     pub price: Money,
 }
 ```
+
+### `garde` 피처 (검증 백엔드)
+
+생성된 DTO에 `validator`의 유지보수되는 대안으로 `garde::Validate`를 활성화합니다. 필드의 `#[validate(...)]` 규칙(`length`, `range`, `email`, `url`, `pattern`)은 garde 문법으로 변환되고, 제약 없는 필드는 `garde(skip)`을 받으며, Update DTO의 Option 래퍼는 `inner(...)`로 내부 값을 검증합니다. 두 피처가 모두 켜져 있으면 `validate`가 우선합니다.
+
+```rust
+#[field(create, update, response)]
+#[validate(length(min = 3, max = 8))]
+pub name: String,
+
+let dto: CreateUserRequest = serde_json::from_str(body)?;
+garde::Validate::validate(&dto)?;
+```


### PR DESCRIPTION
Closes #157.

Adds `garde` as a maintained validation backend — `validator_derive` depends on the unmaintained `proc-macro-error2` (RUSTSEC-2026-0173, currently ignored in deny.toml).

## Behavior

- New facade feature `garde`: generated Create/Update DTOs derive `garde::Validate`
- Field `#[validate(...)]` rules translate to garde syntax: `length(min/max)`, `range(min/max)`, `email`, `url`, `pattern`; unconstrained fields get `garde(skip)` (garde requires per-field annotations)
- Option-wrapped Update DTO fields validate the inner value via `inner(...)` (double-wrapped for nullable PATCH fields); `expected_version` skipped
- Precedence instead of exclusion: when both `validate` and `garde` are enabled, `validate` wins (`cfg_attr(all(garde, not(validate)))`) — deliberate deviation from the issue's mutual-exclusion `compile_error`, which would detonate every `--all-features` build including CI
- deny.toml ignore stays until upstream validator ships a fix (validator remains a dev-dependency)

## Testing

- 4 codegen unit tests (translation, skip, inner-wrapping, precedence gating) — 675 total green
- 4 runtime behavior tests against real garde (`--features postgres,garde`): valid/short/bad-email/Update-inner incl. absent field
- clippy `--all-targets -D warnings` clean, all-features suite green, deny ok

## Docs

- README: feature flags table + "Validation Backends" section
- Wiki (Attributes ×5) updated in this PR — first feature using the in-repo wiki/ flow
- No manual version bumps: release-plz picks this up