### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.22.1](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...v0.22.1) - 2026-07-04
+
+### ✨ Features
+
+- garde validation backend with translated constraints ([#176](https://github.com/RAprogramm/entity-derive/issues/176))
 <!--
 SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
 

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.20.1](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.0...entity-derive-impl-v0.20.1) - 2026-07-04
+
+### ✨ Features
+
+- garde validation backend with translated constraints ([#176](https://github.com/RAprogramm/entity-derive/issues/176))

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.22.0"
+version = "0.22.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-derive-impl`: 0.20.0 -> 0.20.1
* `entity-derive`: 0.22.0 -> 0.22.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-derive-impl`

<blockquote>

## [0.20.1](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.0...entity-derive-impl-v0.20.1) - 2026-07-04

### ✨ Features

- garde validation backend with translated constraints ([#176](https://github.com/RAprogramm/entity-derive/issues/176))
</blockquote>

## `entity-derive`

<blockquote>


## [0.22.1](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...v0.22.1) - 2026-07-04

### ✨ Features

- garde validation backend with translated constraints ([#176](https://github.com/RAprogramm/entity-derive/issues/176))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).