### PR TITLE
159

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -4,7 +4,7 @@ SPDX-PackageSupplier = "RAprogramm <andrey.rozanov.vl@gmail.com>"
 SPDX-PackageDownloadLocation = "https://github.com/RAprogramm/entity-derive"
 
 [[annotations]]
-path = ["README.md", ".gitignore", ".rustfmt.toml", "Cargo.lock", "Cargo.toml", "crates/**/Cargo.toml", "crates/**/tests/**/*.stderr", "wiki/**"]
+path = ["README.md", ".gitignore", ".rustfmt.toml", "Cargo.lock", "Cargo.toml", "CHANGELOG.md", "crates/**/Cargo.toml", "crates/**/CHANGELOG.md", "crates/**/tests/**/*.stderr", "wiki/**"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2025 RAprogramm <andrey.rozanov.vl@gmail.com>"
 SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
Follow-up to #159: the first release-plz PR failed REUSE Compliance — the per-crate `CHANGELOG.md` files it generates carry no licence headers. Extends the aggregate REUSE annotation to cover `CHANGELOG.md` and `crates/**/CHANGELOG.md`.