### PR TITLE
chore: drop stale workspace.package version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.5.0"
 edition = "2024"
 rust-version = "1.96"
 authors = ["RAprogramm <andrey.rozanov.vl@gmail.com>"]


### PR DESCRIPTION
The root `[workspace.package] version = "0.5.0"` is dead configuration: no crate inherits it (each sets its own version; only `rust-version` uses workspace inheritance). It predates the current release scheme and only misleads readers into thinking the workspace is at 0.5.0. Removing it; release-plz manages the real per-crate versions.