### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...HEAD)
 
+## [0.22.2](https://github.com/RAprogramm/entity-derive/compare/v0.22.1...v0.22.2) - 2026-07-04
+
+### 🐛 Bug Fixes
+
+- emit feature-dependent derives at expansion time instead of consumer cfgs ([#186](https://github.com/RAprogramm/entity-derive/issues/186))
+
 ### 🔧 Miscellaneous
 
 - Publish wiki from in-repo sources on merge to main (#174) ([8475551](https://github.com/RAprogramm/entity-derive/commit/84755518dc57af96bde856d8a3526249df8b2f83)) by [@RAprogramm](https://github.com/RAprogramm) in [#174](https://github.com/RAprogramm/entity-derive/pull/174)

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.3](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.2...entity-derive-impl-v0.20.3) - 2026-07-04
+
+### 🐛 Bug Fixes
+
+- emit feature-dependent derives at expansion time instead of consumer cfgs ([#186](https://github.com/RAprogramm/entity-derive/issues/186))
+
 ## [0.20.2](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.1...entity-derive-impl-v0.20.2) - 2026-07-04
 
 ### 🐛 Bug Fixes

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.2"
+version = "0.20.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.22.1"
+version = "0.22.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-derive-impl`: 0.20.2 -> 0.20.3
* `entity-derive`: 0.22.1 -> 0.22.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-derive-impl`

<blockquote>

## [0.20.3](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.2...entity-derive-impl-v0.20.3) - 2026-07-04

### 🐛 Bug Fixes

- emit feature-dependent derives at expansion time instead of consumer cfgs ([#186](https://github.com/RAprogramm/entity-derive/issues/186))
</blockquote>

## `entity-derive`

<blockquote>


## [0.22.2](https://github.com/RAprogramm/entity-derive/compare/v0.22.1...v0.22.2) - 2026-07-04

### 🐛 Bug Fixes

- emit feature-dependent derives at expansion time instead of consumer cfgs ([#186](https://github.com/RAprogramm/entity-derive/issues/186))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).