### PR TITLE
184

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/dialect.rs
+++ b/crates/entity-derive-impl/src/entity/parse/dialect.rs
@@ -72,41 +72,6 @@ impl DatabaseDialect {
             .join(", ")
     }
 
-    /// Get the feature flag name for this dialect.
-    #[must_use]
-    pub const fn feature_flag(&self) -> &'static str {
-        match self {
-            Self::Postgres => "postgres",
-            Self::ClickHouse => "clickhouse",
-            Self::MongoDB => "mongodb"
-        }
-    }
-}
-
-impl FromMeta for DatabaseDialect {
-    fn from_string(value: &str) -> darling::Result<Self> {
-        match value.to_lowercase().as_str() {
-            "postgres" | "postgresql" | "pg" => Ok(Self::Postgres),
-            "clickhouse" | "ch" => Ok(Self::ClickHouse),
-            "mongodb" | "mongo" => Ok(Self::MongoDB),
-            _ => Err(darling::Error::unknown_value(value))
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn postgres_placeholders() {
-        let d = DatabaseDialect::Postgres;
-        assert_eq!(d.placeholder(1), "$1");
-        assert_eq!(d.placeholder(5), "$5");
-        assert_eq!(d.placeholders(3), "$1, $2, $3");
-        assert_eq!(d.placeholders(0), "");
-    }
-
     #[test]
     fn clickhouse_placeholders() {
         let d = DatabaseDialect::ClickHouse;
@@ -119,13 +84,6 @@ mod tests {
         let d = DatabaseDialect::MongoDB;
         assert_eq!(d.placeholder(1), "$1");
         assert_eq!(d.placeholders(3), "$1, $2, $3");
-    }
-
-    #[test]
-    fn feature_flags() {
-        assert_eq!(DatabaseDialect::Postgres.feature_flag(), "postgres");
-        assert_eq!(DatabaseDialect::ClickHouse.feature_flag(), "clickhouse");
-        assert_eq!(DatabaseDialect::MongoDB.feature_flag(), "mongodb");
     }
 
     #[test]

--- a/crates/entity-derive-impl/src/entity/parse/dialect.rs
+++ b/crates/entity-derive-impl/src/entity/parse/dialect.rs
@@ -71,6 +71,31 @@ impl DatabaseDialect {
             .collect::<Vec<_>>()
             .join(", ")
     }
+}
+
+impl FromMeta for DatabaseDialect {
+    fn from_string(value: &str) -> darling::Result<Self> {
+        match value.to_lowercase().as_str() {
+            "postgres" | "postgresql" | "pg" => Ok(Self::Postgres),
+            "clickhouse" | "ch" => Ok(Self::ClickHouse),
+            "mongodb" | "mongo" => Ok(Self::MongoDB),
+            _ => Err(darling::Error::unknown_value(value))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn postgres_placeholders() {
+        let d = DatabaseDialect::Postgres;
+        assert_eq!(d.placeholder(1), "$1");
+        assert_eq!(d.placeholder(5), "$5");
+        assert_eq!(d.placeholders(3), "$1, $2, $3");
+        assert_eq!(d.placeholders(0), "");
+    }
 
     #[test]
     fn clickhouse_placeholders() {

--- a/crates/entity-derive-impl/src/entity/sql/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres.rs
@@ -25,7 +25,6 @@
 //! # Generated Implementation
 //!
 //! ```rust,ignore
-//! #[cfg(feature = "postgres")]
 //! #[async_trait]
 //! impl UserRepository for sqlx::PgPool {
 //!     type Error = sqlx::Error;
@@ -58,7 +57,9 @@
 //!
 //! # Feature Flag
 //!
-//! Generated code is gated behind `#[cfg(feature = "postgres")]`.
+//! The implementation is emitted only when the facade's `postgres`
+//! feature is enabled at expansion time; consumer crates never see the
+//! cfg.
 
 mod bulk;
 mod constraints;
@@ -100,9 +101,12 @@ use crate::{entity::parse::EntityDef, utils::marker};
 /// | Projections | `find_by_id_{projection}` |
 /// | Soft Delete | `hard_delete`, `restore`, `*_with_deleted` |
 pub fn generate(entity: &EntityDef) -> TokenStream {
+    if !cfg!(feature = "postgres") {
+        return TokenStream::new();
+    }
+
     let ctx = Context::new(entity);
     let trait_name = &ctx.trait_name;
-    let feature = entity.dialect.feature_flag();
     let error_type = entity.error_type();
 
     let create_impl = ctx.create_method();
@@ -130,7 +134,6 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         #marker
         #constraint_mapper
 
-        #[cfg(feature = #feature)]
         #[async_trait::async_trait]
         impl #trait_name for sqlx::PgPool {
             type Error = #error_type;

--- a/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
@@ -83,7 +83,6 @@ impl Context<'_> {
 
         quote! {
             /// Resolve a driver error against this entity's constraints.
-            #[cfg(feature = "postgres")]
             fn #fn_name(err: ::sqlx::Error) -> #error_type {
                 if let Some(db_err) = err.as_database_error()
                     && let Some(constraint) = db_err.constraint()


### PR DESCRIPTION
Follow-up to #184 (found by re-validating against a real consumer): the repository `impl` block and the constraints mapper were still wrapped in consumer-side `#[cfg(feature = "postgres")]`, so a consumer without a declared `postgres` feature kept getting `unexpected_cfgs` warnings and silently lost the impl.

- `postgres::generate` now returns nothing when the facade's `postgres` feature is off and emits the impl plainly when it is on
- Constraints mapper cfg removed (already inside the gated generator)
- Module docs updated

Suites green on default, `postgres`, and `--all-features`.