### PR TITLE
202

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -132,6 +132,18 @@ impl EntityDef {
         let command_defs = parse_command_attrs(&input.attrs).map_err(darling::Error::from)?;
         let api_config = parse_api_attr(&input.attrs);
         let indexes = parse_index_attrs(&input.attrs);
+        let field_names: Vec<String> =
+            fields.iter().map(super::super::field::FieldDef::name_str).collect();
+        for index in &indexes {
+            for col in &index.columns {
+                if !field_names.iter().any(|c| c == col) {
+                    return Err(darling::Error::custom(format!(
+                        "index column `{col}` does not match any entity column"
+                    ))
+                    .with_span(&input.ident));
+                }
+            }
+        }
         let custom_constraints =
             parse_constraint_attrs(&input.attrs).map_err(darling::Error::from)?;
         if !custom_constraints.is_empty() && !attrs.typed_constraints {

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -132,8 +132,10 @@ impl EntityDef {
         let command_defs = parse_command_attrs(&input.attrs).map_err(darling::Error::from)?;
         let api_config = parse_api_attr(&input.attrs);
         let indexes = parse_index_attrs(&input.attrs);
-        let field_names: Vec<String> =
-            fields.iter().map(super::super::field::FieldDef::name_str).collect();
+        let field_names: Vec<String> = fields
+            .iter()
+            .map(super::super::field::FieldDef::name_str)
+            .collect();
         for index in &indexes {
             for col in &index.columns {
                 if !field_names.iter().any(|c| c == col) {

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -433,7 +433,63 @@ pub fn generate_lookup_methods(entity: &EntityDef, id_type: &syn::Type) -> Token
         .map(|d| generate_trait_method(&d))
         .collect();
 
-    quote! { #(#methods)* }
+    let composite: Vec<TokenStream> = entity
+        .indexes
+        .iter()
+        .filter(|index| index.unique && index.columns.len() > 1)
+        .filter_map(|index| generate_composite_trait_methods(entity, index))
+        .collect();
+
+    quote! { #(#methods)* #(#composite)* }
+}
+
+/// Generate trait declarations for a composite unique-index lookup pair.
+///
+/// Returns `None` when any index column does not resolve to an entity
+/// field (rejected at parse time, so this is a defensive no-op).
+fn generate_composite_trait_methods(
+    entity: &EntityDef,
+    index: &crate::entity::parse::CompositeIndexDef
+) -> Option<TokenStream> {
+    let entity_name = entity.name();
+    let fields: Vec<&FieldDef> = index
+        .columns
+        .iter()
+        .filter_map(|col| entity.all_fields().iter().find(|f| f.name_str() == *col))
+        .collect();
+    if fields.len() != index.columns.len() {
+        return None;
+    }
+
+    let suffix = fields
+        .iter()
+        .map(|f| f.name_str())
+        .collect::<Vec<_>>()
+        .join("_and_");
+    let find_name = format_ident!("find_by_{}", suffix);
+    let exists_name = format_ident!("exists_by_{}", suffix);
+    let find_params: Vec<TokenStream> = fields
+        .iter()
+        .map(|f| {
+            let name = f.name();
+            let ty = f.ty();
+            quote! { #name: #ty }
+        })
+        .collect();
+    let exists_params = find_params.clone();
+
+    Some(quote! {
+        /// Find a single entity by the composite unique-index columns.
+        ///
+        /// Returns `None` if no record matches; the unique index guarantees
+        /// at most one match.
+        async fn #find_name(&self, #(#find_params),*) -> Result<Option<#entity_name>, Self::Error>;
+
+        /// Check if a record exists for the composite unique-index columns.
+        ///
+        /// Uses `SELECT EXISTS(SELECT 1 FROM ... WHERE a = $1 AND b = $2)`.
+        async fn #exists_name(&self, #(#exists_params),*) -> Result<bool, Self::Error>;
+    })
 }
 
 /// Generate lookup method definitions for a single field.

--- a/crates/entity-derive-impl/src/entity/sql/postgres/lookup.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/lookup.rs
@@ -51,9 +51,28 @@ use quote::{format_ident, quote};
 
 use super::context::Context;
 use crate::{
-    entity::parse::{FieldDef, SqlLevel},
+    entity::parse::{DatabaseDialect, FieldDef, SqlLevel},
     utils::tracing::instrument
 };
+
+/// `a_and_b` method-name suffix for a composite lookup.
+fn composite_suffix(fields: &[&FieldDef]) -> String {
+    fields
+        .iter()
+        .map(|f| f.name_str())
+        .collect::<Vec<_>>()
+        .join("_and_")
+}
+
+/// `a = $1 AND b = $2` WHERE fragment for a composite lookup.
+fn composite_where_clause(fields: &[&FieldDef], dialect: &DatabaseDialect) -> String {
+    fields
+        .iter()
+        .enumerate()
+        .map(|(i, f)| format!("{} = {}", f.name_str(), dialect.placeholder(i + 1)))
+        .collect::<Vec<_>>()
+        .join(" AND ")
+}
 
 impl Context<'_> {
     /// Generate all lookup method implementations.
@@ -77,7 +96,118 @@ impl Context<'_> {
             .flat_map(|field| self.lookup_method_impls(field))
             .collect();
 
-        quote! { #(#methods)* }
+        let composite: Vec<TokenStream> = self
+            .entity
+            .indexes
+            .iter()
+            .filter(|index| index.unique && index.columns.len() > 1)
+            .flat_map(|index| self.composite_lookup_impls(index))
+            .collect();
+
+        quote! { #(#methods)* #(#composite)* }
+    }
+
+    /// Generate `find_by_...` / `exists_by_...` implementations for a
+    /// composite unique index.
+    ///
+    /// Column names resolve to entity fields (validated at parse time),
+    /// the method name joins them with `_and_`.
+    fn composite_lookup_impls(
+        &self,
+        index: &crate::entity::parse::CompositeIndexDef
+    ) -> Vec<TokenStream> {
+        let fields: Vec<&FieldDef> = index
+            .columns
+            .iter()
+            .filter_map(|col| {
+                self.entity
+                    .all_fields()
+                    .iter()
+                    .find(|f| f.name_str() == *col)
+            })
+            .collect();
+        if fields.len() != index.columns.len() {
+            return Vec::new();
+        }
+        vec![
+            self.composite_find_impl(&fields),
+            self.composite_exists_impl(&fields),
+        ]
+    }
+
+    /// Generate the `find_by_{a}_and_{b}` implementation for a composite
+    /// unique index.
+    fn composite_find_impl(&self, fields: &[&FieldDef]) -> TokenStream {
+        let Self {
+            entity_name,
+            row_name,
+            table,
+            dialect,
+            ..
+        } = self;
+
+        let suffix = composite_suffix(fields);
+        let method_name = format_ident!("find_by_{}", suffix);
+        let op = format!("find_by_{suffix}");
+        let span = instrument(&entity_name.to_string(), &op);
+        let params = fields.iter().map(|f| {
+            let name = f.name();
+            let ty = f.ty();
+            quote! { #name: #ty }
+        });
+        let binds = fields.iter().map(|f| {
+            let name = f.name();
+            quote! { .bind(&#name) }
+        });
+        let where_clause = composite_where_clause(fields, dialect);
+        let sql = format!("SELECT * FROM {table} WHERE {where_clause}");
+
+        quote! {
+            #span
+            async fn #method_name(&self, #(#params),*) -> Result<Option<#entity_name>, Self::Error> {
+                let row: Option<#row_name> = sqlx::query_as(#sql)
+                    #(#binds)*
+                    .fetch_optional(self).await?;
+                Ok(row.map(#entity_name::from))
+            }
+        }
+    }
+
+    /// Generate the `exists_by_{a}_and_{b}` implementation for a composite
+    /// unique index.
+    fn composite_exists_impl(&self, fields: &[&FieldDef]) -> TokenStream {
+        let Self {
+            entity_name,
+            table,
+            dialect,
+            ..
+        } = self;
+
+        let suffix = composite_suffix(fields);
+        let method_name = format_ident!("exists_by_{}", suffix);
+        let op = format!("exists_by_{suffix}");
+        let span = instrument(&entity_name.to_string(), &op);
+        let params = fields.iter().map(|f| {
+            let name = f.name();
+            let ty = f.ty();
+            quote! { #name: #ty }
+        });
+        let binds = fields.iter().map(|f| {
+            let name = f.name();
+            quote! { .bind(&#name) }
+        });
+        let where_clause = composite_where_clause(fields, dialect);
+        let sql = format!("SELECT EXISTS(SELECT 1 FROM {table} WHERE {where_clause})");
+
+        quote! {
+            #span
+            async fn #method_name(&self, #(#params),*) -> Result<bool, Self::Error> {
+                let exists: bool = sqlx::query_scalar(#sql)
+                    #(#binds)*
+                    .fetch_one(self).await?;
+                Ok(exists)
+            }
+        }
     }
 
     /// Generate implementation blocks for a single lookup field.
@@ -199,6 +329,63 @@ mod tests {
         assert!(code.contains("async fn exists_by_email"));
         assert!(code.contains("fetch_optional"));
         assert!(code.contains("fetch_one"));
+    }
+
+    #[test]
+    fn composite_unique_index_generates_lookup_pair() {
+        let entity = parse_entity(quote::quote! {
+            #[entity(table = "kyc_sessions", unique_index(provider, external_id))]
+            pub struct KycSession {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub provider: String,
+                #[field(create, response)]
+                pub external_id: String,
+            }
+        });
+
+        let ctx = Context::new(&entity);
+        let code = ctx.lookup_methods().to_string();
+
+        assert!(code.contains("async fn find_by_provider_and_external_id"));
+        assert!(code.contains("async fn exists_by_provider_and_external_id"));
+        assert!(code.contains("provider = $1 AND external_id = $2"));
+    }
+
+    #[test]
+    fn non_unique_composite_index_generates_no_lookup() {
+        let entity = parse_entity(quote::quote! {
+            #[entity(table = "events", index(user_id, created_at))]
+            pub struct Event {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub user_id: uuid::Uuid,
+                #[field(create, response)]
+                pub created_at: chrono::DateTime<chrono::Utc>,
+            }
+        });
+
+        let ctx = Context::new(&entity);
+        let code = ctx.lookup_methods().to_string();
+
+        assert!(!code.contains("find_by_user_id_and_created_at"));
+    }
+
+    #[test]
+    fn index_with_unknown_column_fails_parse() {
+        let input: syn::DeriveInput = syn::parse_quote! {
+            #[entity(table = "kyc_sessions", unique_index(provider, nonexistent))]
+            pub struct KycSession {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                pub provider: String,
+            }
+        };
+        let err = EntityDef::from_derive_input(&input).unwrap_err();
+        assert!(err.to_string().contains("does not match any entity column"));
     }
 
     #[test]

--- a/wiki/Attributes-en.md
+++ b/wiki/Attributes-en.md
@@ -798,6 +798,27 @@ Declare constraints the macro cannot infer — foreign keys over natural keys, c
 )]
 ```
 
+### Composite lookups from `unique_index(...)`
+
+Every multi-column `unique_index(a, b)` declaration generates a lookup pair on the repository:
+
+```rust
+#[derive(Entity)]
+#[entity(table = "kyc_sessions", unique_index(provider, external_id))]
+pub struct KycSession {
+    #[id] pub id: Uuid,
+    #[field(create, response)] pub provider: String,
+    #[field(create, response)] pub external_id: String,
+}
+
+let session = pool.find_by_provider_and_external_id(provider, external_id).await?;
+let taken = pool.exists_by_provider_and_external_id(provider, external_id).await?;
+```
+
+- `find_by_{a}_and_{b}(a, b) -> Option<Entity>` and `exists_by_{a}_and_{b}(a, b) -> bool`
+- Parameter types resolve from the matching entity fields; an index column that does not match any entity column fails the build (same rule as upsert conflict columns)
+- Non-unique `index(...)` declarations generate no lookups
+
 ### Transactional upsert
 
 With both `transactions` and `upsert(...)`, the `{Entity}TransactionRepo` adapter exposes `upsert` with the same SQL and action semantics as the pool method, executed on the transaction handle — for flows where the upsert must share atomicity with adjacent statements.


### PR DESCRIPTION
Closes #202.

Every multi-column `unique_index(a, b, ...)` now generates a lookup pair on the repository trait and the PgPool implementation:

- `find_by_{a}_and_{b}(a, b) -> Result<Option<Entity>, Self::Error>`
- `exists_by_{a}_and_{b}(a, b) -> Result<bool, Self::Error>`

Parameter types resolve from the matching entity fields. Index columns are now validated at parse time — a column that does not match any entity field fails the build with the same wording as upsert conflict validation. Non-unique `index(...)` declarations generate no lookups.

Wiki (Attributes-en) documents the feature.