### PR TITLE
204

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Docs Site
+
+on:
+  push:
+    branches: [main]
+    paths: ["wiki/**", "site/**", ".github/workflows/site.yml"]
+  pull_request:
+    paths: ["wiki/**", "site/**", ".github/workflows/site.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build site from wiki
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install mdBook
+        uses: taiki-e/install-action@v2
+        with:
+          tool: mdbook@0.5.3
+
+      - name: Build site
+        run: python3 site/build.py --out "$RUNNER_TEMP/site"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ${{ runner.temp }}/site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@
   <a href="https://github.com/RAprogramm/entity-derive/wiki">
     <img src="https://img.shields.io/badge/Wiki-Documentation-green?style=for-the-badge&logo=github" alt="Wiki"/>
   </a>
+  <a href="https://raprogramm.github.io/entity-derive/">
+    <img src="https://img.shields.io/badge/Docs-Website-blue?style=for-the-badge&logo=mdbook" alt="Documentation Site"/>
+  </a>
 </p>
 
 ---

--- a/site/build.py
+++ b/site/build.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+"""Build the multilingual documentation site from wiki/ with mdBook.
+
+Parses wiki/_Sidebar.md to discover languages and page order, generates one
+mdBook per language, rewrites wiki-style links to book-relative links, and
+assembles the final site with a landing page at the output root.
+
+Usage: python3 site/build.py --out <output-directory>
+"""
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import unquote
+
+REPO_URL = "https://github.com/RAprogramm/entity-derive"
+WIKI_URL = REPO_URL + "/wiki/"
+LANGUAGES = {
+    "English": "en",
+    "Русский": "ru",
+    "한국어": "ko",
+    "Español": "es",
+    "中文": "zh",
+}
+
+HOME_RE = re.compile(r"^\*\*\[(.+?)\]\((\S+?)\)\*\*$")
+PART_RE = re.compile(r"^\*\*(.+?)\*\*$")
+PAGE_RE = re.compile(r"^- \[(.+?)\]\((\S+?)\)$")
+HEADING_RE = re.compile(r"^## (.+)$")
+LINK_RE = re.compile(r"\]\(([^)\s]+)\)")
+
+
+def slug_of(url):
+    return unquote(url.rsplit("/", 1)[-1])
+
+
+def parse_sidebar(text):
+    """Return {lang: [(kind, title, slug?), ...]} in sidebar order."""
+    books = {}
+    current = None
+    for raw in text.splitlines():
+        line = raw.strip()
+        heading = HEADING_RE.match(line)
+        if heading:
+            current = None
+            for name, code in LANGUAGES.items():
+                if name in heading.group(1):
+                    current = code
+                    books[code] = []
+            continue
+        if current is None:
+            continue
+        m = HOME_RE.match(line)
+        if m:
+            books[current].append(("home", m.group(1), slug_of(m.group(2))))
+            continue
+        m = PART_RE.match(line)
+        if m:
+            books[current].append(("part", m.group(1), None))
+            continue
+        m = PAGE_RE.match(line)
+        if m:
+            books[current].append(("page", m.group(1), slug_of(m.group(2))))
+    return books
+
+
+def rewrite_links(text, lang, slug_lang):
+    """Rewrite wiki links: same book -> page.md, other book -> ../lang/page.html."""
+
+    def repl(match):
+        target = match.group(1)
+        if target.startswith(WIKI_URL):
+            target = target[len(WIKI_URL):]
+        elif "://" in target or target.startswith(("#", "mailto:")):
+            return match.group(0)
+        slug, _, anchor = target.partition("#")
+        slug = unquote(slug)
+        if slug not in slug_lang:
+            return match.group(0)
+        suffix = "#" + anchor if anchor else ""
+        if slug_lang[slug] == lang:
+            return "](" + slug + ".md" + suffix + ")"
+        return "](../" + slug_lang[slug] + "/" + slug + ".html" + suffix + ")"
+
+    return LINK_RE.sub(repl, text)
+
+
+def book_toml(lang):
+    return (
+        "[book]\n"
+        'title = "entity-derive"\n'
+        'language = "' + lang + '"\n'
+        'src = "src"\n'
+        "\n"
+        "[output.html]\n"
+        'site-url = "/entity-derive/' + lang + '/"\n'
+        'git-repository-url = "' + REPO_URL + '"\n'
+        'edit-url-template = "' + REPO_URL + '/edit/main/wiki/{path}"\n'
+    )
+
+
+def build_book(lang, items, wiki_dir, work_dir, out_dir, slug_lang):
+    book_dir = work_dir / lang
+    src_dir = book_dir / "src"
+    src_dir.mkdir(parents=True)
+    summary = ["# Summary", ""]
+    for kind, title, slug in items:
+        if kind == "home":
+            summary += ["[" + title + "](" + slug + ".md)", ""]
+        elif kind == "part":
+            summary += ["# " + title, ""]
+        else:
+            summary.append("- [" + title + "](" + slug + ".md)")
+    (src_dir / "SUMMARY.md").write_text("\n".join(summary) + "\n", encoding="utf-8")
+    for kind, _title, slug in items:
+        if kind == "part":
+            continue
+        text = (wiki_dir / (slug + ".md")).read_text(encoding="utf-8")
+        (src_dir / (slug + ".md")).write_text(
+            rewrite_links(text, lang, slug_lang), encoding="utf-8"
+        )
+    (book_dir / "book.toml").write_text(book_toml(lang), encoding="utf-8")
+    subprocess.run(
+        ["mdbook", "build", "--dest-dir", str(out_dir / lang)],
+        cwd=book_dir,
+        check=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, type=Path)
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parent.parent
+    wiki_dir = repo_root / "wiki"
+    out_dir = args.out.resolve()
+
+    books = parse_sidebar((wiki_dir / "_Sidebar.md").read_text(encoding="utf-8"))
+    missing = sorted(set(LANGUAGES.values()) - set(books))
+    if missing:
+        sys.exit("languages missing from wiki/_Sidebar.md: " + ", ".join(missing))
+
+    slug_lang = {
+        slug: lang
+        for lang, items in books.items()
+        for kind, _title, slug in items
+        if kind != "part"
+    }
+
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    out_dir.mkdir(parents=True)
+
+    with tempfile.TemporaryDirectory() as work:
+        for lang, items in books.items():
+            build_book(lang, items, wiki_dir, Path(work), out_dir, slug_lang)
+
+    shutil.copy(repo_root / "site" / "landing.html", out_dir / "index.html")
+    shutil.copy(repo_root / "logo.png", out_dir / "logo.png")
+    print("site built at", out_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/landing.html
+++ b/site/landing.html
@@ -1,0 +1,97 @@
+<!-- SPDX-FileCopyrightText: 2026 RAprogramm <andrey.rozanov.vl@gmail.com> -->
+<!-- SPDX-License-Identifier: MIT -->
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="description" content="entity-derive documentation — generate DTOs, repositories, mappers, and SQL from a single entity definition">
+<title>entity-derive — Documentation</title>
+<link rel="icon" type="image/png" href="logo.png">
+<style>
+  :root {
+    --bg: #fdfdfd;
+    --fg: #1f2328;
+    --muted: #57606a;
+    --card-bg: #ffffff;
+    --card-border: #d0d7de;
+    --card-hover: #0969da;
+    --accent: #0969da;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0d1117;
+      --fg: #e6edf3;
+      --muted: #8d96a0;
+      --card-bg: #161b22;
+      --card-border: #30363d;
+      --card-hover: #58a6ff;
+      --accent: #58a6ff;
+    }
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem 1rem;
+    text-align: center;
+  }
+  img.logo { width: 140px; height: 140px; }
+  h1 { margin-top: 1rem; font-size: 2.2rem; }
+  p.tagline { margin-top: .5rem; color: var(--muted); font-size: 1.1rem; font-style: italic; }
+  nav.languages {
+    margin-top: 2.5rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+    width: 100%;
+    max-width: 900px;
+  }
+  nav.languages a {
+    background: var(--card-bg);
+    border: 1px solid var(--card-border);
+    border-radius: 12px;
+    padding: 1.4rem 1rem;
+    text-decoration: none;
+    color: var(--fg);
+    transition: border-color .15s, transform .15s;
+    display: flex;
+    flex-direction: column;
+    gap: .4rem;
+  }
+  nav.languages a:hover {
+    border-color: var(--card-hover);
+    transform: translateY(-2px);
+  }
+  nav.languages .flag { font-size: 2rem; }
+  nav.languages .name { font-weight: 600; font-size: 1.05rem; }
+  nav.languages .label { color: var(--muted); font-size: .9rem; }
+  footer { margin-top: 3rem; color: var(--muted); font-size: .95rem; }
+  footer a { color: var(--accent); text-decoration: none; }
+  footer a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+  <img class="logo" src="logo.png" alt="entity-derive logo">
+  <h1>entity-derive</h1>
+  <p class="tagline">One macro to rule them all</p>
+  <nav class="languages" aria-label="Documentation language">
+    <a href="en/"><span class="flag">🇬🇧</span><span class="name">English</span><span class="label">Documentation</span></a>
+    <a href="ru/" lang="ru"><span class="flag">🇷🇺</span><span class="name">Русский</span><span class="label">Документация</span></a>
+    <a href="ko/" lang="ko"><span class="flag">🇰🇷</span><span class="name">한국어</span><span class="label">문서</span></a>
+    <a href="es/" lang="es"><span class="flag">🇪🇸</span><span class="name">Español</span><span class="label">Documentación</span></a>
+    <a href="zh/" lang="zh"><span class="flag">🇨🇳</span><span class="name">中文</span><span class="label">文档</span></a>
+  </nav>
+  <footer>
+    <a href="https://docs.rs/entity-derive">API&nbsp;Docs</a> ·
+    <a href="https://crates.io/crates/entity-derive">crates.io</a> ·
+    <a href="https://github.com/RAprogramm/entity-derive">GitHub</a>
+  </footer>
+</body>
+</html>

--- a/wiki/Inicio.md
+++ b/wiki/Inicio.md
@@ -5,10 +5,10 @@
 > Una macro para gobernarlos a todos
 
 [![English](https://img.shields.io/badge/🇬🇧_English-gray?style=for-the-badge)](Home-en)
-[![Русский](https://img.shields.io/badge/🇷🇺_Русский-gray?style=for-the-badge)](Home-ru)
-[![한국어](https://img.shields.io/badge/🇰🇷_한국어-gray?style=for-the-badge)](Home-ko)
+[![Русский](https://img.shields.io/badge/🇷🇺_Русский-gray?style=for-the-badge)](Главная)
+[![한국어](https://img.shields.io/badge/🇰🇷_한국어-gray?style=for-the-badge)](홈)
 [![Español](https://img.shields.io/badge/🇪🇸_Español-blue?style=for-the-badge)](#)
-[![中文](https://img.shields.io/badge/🇨🇳_中文-gray?style=for-the-badge)](Home-zh)
+[![中文](https://img.shields.io/badge/🇨🇳_中文-gray?style=for-the-badge)](首页)
 
 </div>
 

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -7,6 +7,6 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://github.com/RAprogramm/entity-derive/blob/main/LICENSES/MIT.txt)
 [![GitHub](https://img.shields.io/badge/GitHub-repo-black?style=flat-square&logo=github)](https://github.com/RAprogramm/entity-derive)
 
-[🇬🇧 English](Home-en) | [🇷🇺 Русский](Home-ru) | [🇰🇷 한국어](Home-ko) | [🇪🇸 Español](Home-es) | [🇨🇳 中文](Home-zh)
+[🇬🇧 English](Home-en) | [🇷🇺 Русский](Главная) | [🇰🇷 한국어](홈) | [🇪🇸 Español](Inicio) | [🇨🇳 中文](首页)
 
 </div>

--- a/wiki/Главная.md
+++ b/wiki/Главная.md
@@ -6,9 +6,9 @@
 
 [![English](https://img.shields.io/badge/🇬🇧_English-gray?style=for-the-badge)](Home-en)
 [![Русский](https://img.shields.io/badge/🇷🇺_Русский-blue?style=for-the-badge)](#)
-[![한국어](https://img.shields.io/badge/🇰🇷_한국어-gray?style=for-the-badge)](Home-ko)
-[![Español](https://img.shields.io/badge/🇪🇸_Español-gray?style=for-the-badge)](Home-es)
-[![中文](https://img.shields.io/badge/🇨🇳_中文-gray?style=for-the-badge)](Home-zh)
+[![한국어](https://img.shields.io/badge/🇰🇷_한국어-gray?style=for-the-badge)](홈)
+[![Español](https://img.shields.io/badge/🇪🇸_Español-gray?style=for-the-badge)](Inicio)
+[![中文](https://img.shields.io/badge/🇨🇳_中文-gray?style=for-the-badge)](首页)
 
 </div>
 

--- a/wiki/首页.md
+++ b/wiki/首页.md
@@ -5,9 +5,9 @@
 > 一个宏统治一切
 
 [![English](https://img.shields.io/badge/🇬🇧_English-gray?style=for-the-badge)](Home-en)
-[![Русский](https://img.shields.io/badge/🇷🇺_Русский-gray?style=for-the-badge)](Home-ru)
-[![한국어](https://img.shields.io/badge/🇰🇷_한국어-gray?style=for-the-badge)](Home-ko)
-[![Español](https://img.shields.io/badge/🇪🇸_Español-gray?style=for-the-badge)](Home-es)
+[![Русский](https://img.shields.io/badge/🇷🇺_Русский-gray?style=for-the-badge)](Главная)
+[![한국어](https://img.shields.io/badge/🇰🇷_한국어-gray?style=for-the-badge)](홈)
+[![Español](https://img.shields.io/badge/🇪🇸_Español-gray?style=for-the-badge)](Inicio)
 [![中文](https://img.shields.io/badge/🇨🇳_中文-blue?style=for-the-badge)](#)
 
 </div>

--- a/wiki/홈.md
+++ b/wiki/홈.md
@@ -5,10 +5,10 @@
 > 모든 것을 지배하는 하나의 매크로
 
 [![English](https://img.shields.io/badge/🇬🇧_English-gray?style=for-the-badge)](Home-en)
-[![Русский](https://img.shields.io/badge/🇷🇺_Русский-gray?style=for-the-badge)](Home-ru)
+[![Русский](https://img.shields.io/badge/🇷🇺_Русский-gray?style=for-the-badge)](Главная)
 [![한국어](https://img.shields.io/badge/🇰🇷_한국어-blue?style=for-the-badge)](#)
-[![Español](https://img.shields.io/badge/🇪🇸_Español-gray?style=for-the-badge)](Home-es)
-[![中文](https://img.shields.io/badge/🇨🇳_中文-gray?style=for-the-badge)](Home-zh)
+[![Español](https://img.shields.io/badge/🇪🇸_Español-gray?style=for-the-badge)](Inicio)
+[![中文](https://img.shields.io/badge/🇨🇳_中文-gray?style=for-the-badge)](首页)
 
 </div>
 


### PR DESCRIPTION
Closes #204

Adds a GitHub Pages documentation site built automatically from `wiki/`:

- `site/build.py` parses `wiki/_Sidebar.md`, generates one mdBook per language (en, ru, ko, es, zh), rewrites wiki-style links (same book → `page.md`, cross-language → `../lang/page.html`), and assembles the site with a landing page and logo at the root
- `site/landing.html` — language-selection landing page (light/dark)
- `.github/workflows/site.yml` — builds on PRs touching `wiki/**`/`site/**` and deploys to Pages on push to `main`; mdBook pinned to 0.5.3, Pages actions at latest (upload-pages-artifact v5, deploy-pages v5)
- fixes pre-existing broken language-switcher links (`Home-ru`/`Home-ko`/`Home-es`/`Home-zh`) in 4 wiki home pages and `_Footer.md`
- README: adds a Docs Website badge

Wiki stays the single source of content; the site redeploys on every wiki change. No existing code, CI, or the wiki-sync workflow is touched. Verified locally: all 5 books build with mdBook 0.5, every internal link in the generated HTML resolves, `reuse lint` passes (344/344).