### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...HEAD)
 
+## [0.22.5](https://github.com/RAprogramm/entity-derive/compare/v0.22.4...v0.22.5) - 2026-07-05
+
+### ✨ Features
+
+- documentation site generated from wiki ([#206](https://github.com/RAprogramm/entity-derive/issues/206))
+
+### 🐛 Bug Fixes
+
+- upsert overwrites only update-marked columns on conflict ([#209](https://github.com/RAprogramm/entity-derive/issues/209))
+
 ## [0.22.4](https://github.com/RAprogramm/entity-derive/compare/v0.22.3...v0.22.4) - 2026-07-04
 
 ### ✨ Features

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.10](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.9...entity-derive-impl-v0.20.10) - 2026-07-05
+
+### 🐛 Bug Fixes
+
+- upsert overwrites only update-marked columns on conflict ([#209](https://github.com/RAprogramm/entity-derive/issues/209))
+
 ## [0.20.9](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.8...entity-derive-impl-v0.20.9) - 2026-07-05
 
 ## [0.20.8](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.7...entity-derive-impl-v0.20.8) - 2026-07-05

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.9"
+version = "0.20.10"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.22.4"
+version = "0.22.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-derive-impl`: 0.20.9 -> 0.20.10
* `entity-derive`: 0.22.4 -> 0.22.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-derive-impl`

<blockquote>

## [0.20.10](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.9...entity-derive-impl-v0.20.10) - 2026-07-05

### 🐛 Bug Fixes

- upsert overwrites only update-marked columns on conflict ([#209](https://github.com/RAprogramm/entity-derive/issues/209))
</blockquote>

## `entity-derive`

<blockquote>


## [0.22.5](https://github.com/RAprogramm/entity-derive/compare/v0.22.4...v0.22.5) - 2026-07-05

### ✨ Features

- documentation site generated from wiki ([#206](https://github.com/RAprogramm/entity-derive/issues/206))

### 🐛 Bug Fixes

- upsert overwrites only update-marked columns on conflict ([#209](https://github.com/RAprogramm/entity-derive/issues/209))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).