### PR TITLE
207

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -438,11 +438,11 @@ fn validate_upsert(
     if upsert.action == UpsertAction::Update {
         let has_updatable_column = fields.iter().any(|f| {
             let col = f.name_str();
-            !f.is_id() && !conflict.contains(&col)
+            f.in_update() && !f.is_id() && !f.is_auto() && !conflict.contains(&col)
         });
         if !has_updatable_column {
             return Err(darling::Error::custom(
-                "upsert action = \"update\" needs at least one non-conflict column to update; use action = \"nothing\" instead"
+                "upsert action = \"update\" needs at least one non-conflict #[field(update)] column: only updatable columns are overwritten on conflict; use action = \"nothing\" instead"
             )
             .with_span(span));
         }

--- a/crates/entity-derive-impl/src/entity/sql/postgres/upsert.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/upsert.rs
@@ -16,8 +16,12 @@
 //!
 //! | Action | SQL | Return type |
 //! |--------|-----|-------------|
-//! | `update` | `DO UPDATE SET` all non-conflict, non-id columns | `Entity` |
+//! | `update` | `DO UPDATE SET` non-conflict `#[field(update)]` columns | `Entity` |
 //! | `nothing` | `DO NOTHING` | `Option<Entity>` (`None` = row already existed) |
+//!
+//! Columns not marked `#[field(update)]` keep their stored values on
+//! conflict: the insert path binds them from the Create DTO defaults, so
+//! overwriting them would clobber real data with `Default::default()`.
 //!
 //! The SQL string is assembled entirely at macro expansion time from
 //! entity metadata, so the generated code carries a `'static` literal.
@@ -33,10 +37,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::{context::Context, crud::tx_wrapping, helpers::insert_bindings};
-use crate::{
-    entity::parse::{FieldDef, UpsertAction},
-    utils::tracing::instrument
-};
+use crate::{entity::parse::UpsertAction, utils::tracing::instrument};
 
 impl Context<'_> {
     /// Generate the `upsert` method implementation.
@@ -129,11 +130,11 @@ impl Context<'_> {
             UpsertAction::Update => {
                 let assignments: Vec<String> = self
                     .entity
-                    .column_fields()
+                    .update_fields()
                     .into_iter()
                     .filter(|f| {
                         let col = f.name_str();
-                        !FieldDef::is_id(f) && !f.storage.is_auto && !conflict.contains(&col)
+                        f.embed.is_none() && !conflict.contains(&col)
                     })
                     .map(|f| {
                         let col = f.name_str();
@@ -212,12 +213,55 @@ mod tests {
                 #[field(create, response)]
                 #[column(unique)]
                 pub email: String,
-                #[field(create, response)]
+                #[field(create, update, response)]
                 pub name: String,
             }
         });
         let ctx = Context::new(&entity);
         assert!(ctx.upsert_sql().starts_with("INSERT INTO core.users "));
+    }
+
+    #[test]
+    fn upsert_sql_skips_non_updatable_columns() {
+        let entity = parse_entity(quote! {
+            #[entity(table = "users", upsert(conflict = "telegram_id"))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[column(unique)]
+                pub telegram_id: i64,
+                #[field(create, update, response)]
+                pub username: String,
+                pub passport_verified: bool,
+            }
+        });
+        let ctx = Context::new(&entity);
+        assert_eq!(
+            ctx.upsert_sql(),
+            "INSERT INTO users (id, telegram_id, username, passport_verified) \
+             VALUES ($1, $2, $3, $4) \
+             ON CONFLICT (telegram_id) DO UPDATE SET username = EXCLUDED.username RETURNING *"
+        );
+    }
+
+    #[test]
+    fn upsert_update_without_updatable_columns_fails_parse() {
+        let input: DeriveInput = syn::parse2(quote! {
+            #[entity(table = "users", upsert(conflict = "email"))]
+            pub struct User {
+                #[id]
+                pub id: uuid::Uuid,
+                #[field(create, response)]
+                #[column(unique)]
+                pub email: String,
+                #[field(create, response)]
+                pub name: String,
+            }
+        })
+        .expect("test entity must parse");
+        let err = EntityDef::from_derive_input(&input).unwrap_err();
+        assert!(err.to_string().contains("#[field(update)]"));
     }
 
     #[test]

--- a/crates/entity-derive/tests/cases/fail/upsert_no_updatable_columns.stderr
+++ b/crates/entity-derive/tests/cases/fail/upsert_no_updatable_columns.stderr
@@ -1,4 +1,4 @@
-error: upsert action = "update" needs at least one non-conflict column to update; use action = "nothing" instead
+error: upsert action = "update" needs at least one non-conflict #[field(update)] column: only updatable columns are overwritten on conflict; use action = "nothing" instead
  --> tests/cases/fail/upsert_no_updatable_columns.rs:9:12
   |
 9 | pub struct Subscription {

--- a/wiki/Attributes-en.md
+++ b/wiki/Attributes-en.md
@@ -200,13 +200,13 @@ pub struct User {
 | `action` | No | `"update"` | `"update"` (DO UPDATE) or `"nothing"` (DO NOTHING) |
 
 **Generated:**
-- `action = "update"` → `async fn upsert(&self, dto: CreateUserRequest) -> Result<User, Error>` — overwrites all non-conflict columns (`DO UPDATE SET col = EXCLUDED.col`) and returns the persisted row
+- `action = "update"` → `async fn upsert(&self, dto: CreateUserRequest) -> Result<User, Error>` — overwrites the non-conflict `#[field(update)]` columns (`DO UPDATE SET col = EXCLUDED.col`) and returns the persisted row; columns not marked updatable keep their stored values on conflict
 - `action = "nothing"` → `async fn upsert(&self, dto: CreateUserRequest) -> Result<Option<User>, Error>` — keeps the existing row untouched; `None` means a conflicting row already existed
 
 **Compile-time validation:**
 - conflict columns must exist and carry a uniqueness guarantee (`#[id]`, `#[column(unique)]` or a matching `unique_index(...)`)
 - requires `returning = "full"` (the default)
-- `action = "update"` needs at least one non-conflict updatable column
+- `action = "update"` needs at least one non-conflict `#[field(update)]` column
 
 With `streams` enabled, upsert publishes a `Created` notification for every row it returns.
 


### PR DESCRIPTION
Closes #207.

`upsert(action = "update")` built its `DO UPDATE SET` list from every non-id, non-auto, non-conflict column. Plain (unmarked) fields are bound from Create-DTO defaults on the insert path, so a conflict overwrote real data with `Default::default()` — e.g. a login upsert on a `users` entity reset a plain `passport_verified` column back to `false` on every sign-in.

- SET list now covers non-conflict `#[field(update)]` columns only, matching the mutability contract of `update`; unmarked columns keep their stored values on conflict.
- Validation tightened to match: `action = "update"` requires at least one non-conflict `#[field(update)]` column (previously any non-conflict column counted, which allowed an entity whose fixed SET list would now be empty).
- Trybuild snapshot and wiki (Attributes-en) updated.