### PR TITLE
210

### DIFF
--- a/site/build.py
+++ b/site/build.py
@@ -103,6 +103,9 @@ def book_toml(lang):
         'site-url = "/entity-derive/' + lang + '/"\n'
         'git-repository-url = "' + REPO_URL + '"\n'
         'edit-url-template = "' + REPO_URL + '/edit/main/wiki/{path}"\n'
+        "\n"
+        "[output.html.playground]\n"
+        "runnable = false\n"
     )
 
 


### PR DESCRIPTION
Closes #210

Disables the mdBook playground run button in the generated documentation books. The examples depend on entity-derive and a live Postgres database, neither available on the Rust Playground, so the button could never succeed.

Verified locally: rebuilt site has zero `playground` code blocks (was 10 on the English Examples page alone); everything else in the generated HTML is unchanged.