### PR TITLE
chore: release

### DIFF
--- a/crates/entity-core/CHANGELOG.md
+++ b/crates/entity-core/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.10.1](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.0...entity-core-v0.10.1) - 2026-07-05
+
+### ✨ Features
+
+- declarative state-machine transitions on the transaction adapter ([#223](https://github.com/RAprogramm/entity-derive/issues/223))

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.10.0"
+version = "0.10.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.13](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.12...entity-derive-impl-v0.20.13) - 2026-07-05
+
+### ✨ Features
+
+- declarative state-machine transitions on the transaction adapter ([#223](https://github.com/RAprogramm/entity-derive/issues/223))
+
 ## [0.20.12](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.11...entity-derive-impl-v0.20.12) - 2026-07-05
 
 ### ✨ Features

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.12"
+version = "0.20.13"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-core`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `entity-derive-impl`: 0.20.12 -> 0.20.13

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-core`

<blockquote>

## [0.10.1](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.0...entity-core-v0.10.1) - 2026-07-05

### ✨ Features

- declarative state-machine transitions on the transaction adapter ([#223](https://github.com/RAprogramm/entity-derive/issues/223))
</blockquote>

## `entity-derive-impl`

<blockquote>

## [0.20.13](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.12...entity-derive-impl-v0.20.13) - 2026-07-05

### ✨ Features

- declarative state-machine transitions on the transaction adapter ([#223](https://github.com/RAprogramm/entity-derive/issues/223))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).