### PR TITLE
chore: release

### DIFF
--- a/crates/entity-core/CHANGELOG.md
+++ b/crates/entity-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.1...entity-core-v0.10.2) - 2026-07-05
+
+### ✨ Features
+
+- runtime schema assertion for entities ([#225](https://github.com/RAprogramm/entity-derive/issues/225))
+
 ## [0.10.1](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.0...entity-core-v0.10.1) - 2026-07-05
 
 ### ✨ Features

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.10.1"
+version = "0.10.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.14](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.13...entity-derive-impl-v0.20.14) - 2026-07-05
+
+### ✨ Features
+
+- runtime schema assertion for entities ([#225](https://github.com/RAprogramm/entity-derive/issues/225))
+
 ## [0.20.13](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.12...entity-derive-impl-v0.20.13) - 2026-07-05
 
 ### ✨ Features

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.13"
+version = "0.20.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-core`: 0.10.1 -> 0.10.2 (✓ API compatible changes)
* `entity-derive-impl`: 0.20.13 -> 0.20.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-core`

<blockquote>

## [0.10.2](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.1...entity-core-v0.10.2) - 2026-07-05

### ✨ Features

- runtime schema assertion for entities ([#225](https://github.com/RAprogramm/entity-derive/issues/225))
</blockquote>

## `entity-derive-impl`

<blockquote>

## [0.20.14](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.13...entity-derive-impl-v0.20.14) - 2026-07-05

### ✨ Features

- runtime schema assertion for entities ([#225](https://github.com/RAprogramm/entity-derive/issues/225))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).