### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...HEAD)
 
+## [0.22.6](https://github.com/RAprogramm/entity-derive/compare/v0.22.5...v0.22.6) - 2026-07-21
+
+### ✨ Features
+
+- derive utoipa::ToSchema on joined read models under the api feature ([#228](https://github.com/RAprogramm/entity-derive/issues/228))
+
 ## [0.22.5](https://github.com/RAprogramm/entity-derive/compare/v0.22.4...v0.22.5) - 2026-07-05
 
 ### ✨ Features

--- a/crates/entity-core/CHANGELOG.md
+++ b/crates/entity-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.3](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.2...entity-core-v0.10.3) - 2026-07-21
+
+### 🐛 Bug Fixes
+
+- fold time/timetz types in schema drift normalizer ([#233](https://github.com/RAprogramm/entity-derive/issues/233))
+
 ## [0.10.2](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.1...entity-core-v0.10.2) - 2026-07-05
 
 ### ✨ Features

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.10.2"
+version = "0.10.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.15](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.14...entity-derive-impl-v0.20.15) - 2026-07-21
+
+### ✨ Features
+
+- derive utoipa::ToSchema on joined read models under the api feature ([#228](https://github.com/RAprogramm/entity-derive/issues/228))
+
 ## [0.20.14](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.13...entity-derive-impl-v0.20.14) - 2026-07-05
 
 ### ✨ Features

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.14"
+version = "0.20.15"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.22.5"
+version = "0.22.6"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-core`: 0.10.2 -> 0.10.3 (✓ API compatible changes)
* `entity-derive-impl`: 0.20.14 -> 0.20.15
* `entity-derive`: 0.22.5 -> 0.22.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-core`

<blockquote>

## [0.10.3](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.2...entity-core-v0.10.3) - 2026-07-21

### 🐛 Bug Fixes

- fold time/timetz types in schema drift normalizer ([#233](https://github.com/RAprogramm/entity-derive/issues/233))
</blockquote>

## `entity-derive-impl`

<blockquote>

## [0.20.15](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.14...entity-derive-impl-v0.20.15) - 2026-07-21

### ✨ Features

- derive utoipa::ToSchema on joined read models under the api feature ([#228](https://github.com/RAprogramm/entity-derive/issues/228))
</blockquote>

## `entity-derive`

<blockquote>


## [0.22.6](https://github.com/RAprogramm/entity-derive/compare/v0.22.5...v0.22.6) - 2026-07-21

### ✨ Features

- derive utoipa::ToSchema on joined read models under the api feature ([#228](https://github.com/RAprogramm/entity-derive/issues/228))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).