### PR TITLE
#234 test: execute generated SQL against a live Postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
           tool: cargo-nextest
 
       - name: Run tests
-        run: cargo nextest run --all-features --profile ci --no-tests=pass
+        run: cargo nextest run --all-features --profile ci --no-tests=pass -E 'not binary(postgres)'
 
       - name: Run doctests
         run: cargo test --doc --all-features || true
@@ -229,6 +229,54 @@ jobs:
           report_type: test_results
           fail_ci_if_error: false
 
+  postgres:
+    name: Live Postgres (${{ matrix.postgres }})
+    needs: [check, fmt, security, reuse]
+    if: ${{ !inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Two most recent stable majors: the generated DDL and SQL must
+        # hold on the version users run today and the one before it.
+        postgres: ["18", "17"]
+    services:
+      postgres:
+        image: postgres:${{ matrix.postgres }}-alpine
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: test
+          save-if: false
+
+      - name: Install nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      # --no-tests=fail: an empty target here would mean the suite
+      # silently stopped covering the generated SQL.
+      - name: Run generated SQL against Postgres
+        env:
+          ENTITY_DERIVE_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+        run: cargo nextest run -p entity-derive --all-features --test postgres --profile ci --no-tests=fail
+
   coverage:
     name: Coverage
     needs: test
@@ -255,7 +303,7 @@ jobs:
 
       - name: Generate coverage
         run: |
-          cargo llvm-cov nextest --all-features --profile ci --lcov --output-path lcov.info
+          cargo llvm-cov nextest --all-features --profile ci --lcov --output-path lcov.info -E 'not binary(postgres)'
           cargo llvm-cov report --html
 
       - name: Upload to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,10 @@ jobs:
       postgres:
         image: postgres:${{ matrix.postgres }}-alpine
         env:
-          POSTGRES_PASSWORD: postgres
+          # The container is reachable only from this job and is thrown
+          # away with it, so it takes no password at all rather than a
+          # hardcoded one.
+          POSTGRES_HOST_AUTH_METHOD: trust
         ports:
           - 5432:5432
         options: >-
@@ -274,7 +277,7 @@ jobs:
       # silently stopped covering the generated SQL.
       - name: Run generated SQL against Postgres
         env:
-          ENTITY_DERIVE_TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
+          ENTITY_DERIVE_TEST_DATABASE_URL: postgres://postgres@localhost:5432/postgres
         run: cargo nextest run -p entity-derive --all-features --test postgres --profile ci --no-tests=fail
 
   coverage:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,25 @@ cargo clippy -- -D warnings
 cargo test
 ```
 
+## Live Postgres suite
+
+`crates/entity-derive/tests/postgres.rs` runs the *generated* SQL —
+migrations, CRUD, upsert, keyset pagination, soft delete, lookups,
+projections, optimistic locking — against a real server. Point it at
+one and it provisions a throwaway database per test:
+
+```bash
+ENTITY_DERIVE_TEST_DATABASE_URL=postgres://postgres@localhost/postgres \
+  cargo test -p entity-derive --all-features --test postgres
+```
+
+`DATABASE_URL` works as a fallback. Without either variable the tests
+print a notice and pass, so no local server is required to contribute;
+CI always provides one, and there the missing variable is a hard error.
+
+A test that panics leaves its database behind for inspection — the next
+run drops it once it is half an hour old.
+
 ## CI checks
 
 | Check | Command |
@@ -47,6 +66,7 @@ cargo test
 | Format | `cargo +nightly fmt --check` |
 | Lint | `cargo clippy -- -D warnings` |
 | Test | `cargo test` |
+| Live Postgres | `cargo nextest run -p entity-derive --all-features --test postgres` (matrix: Postgres 18, 17) |
 | Coverage | `cargo llvm-cov` (95%+ required) |
 
 ## Code standards

--- a/crates/entity-derive/tests/pg/mod.rs
+++ b/crates/entity-derive/tests/pg/mod.rs
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Live-Postgres harness for the generated-SQL integration suite.
+//!
+//! The rest of the test suite proves that the macro *compiles*. This
+//! harness lets a test prove that what the macro emitted is also valid
+//! SQL: every case provisions a throwaway database, applies the
+//! entity's generated `MIGRATION_UP`, exercises the generated
+//! repository methods against a real server, and drops the database
+//! again.
+//!
+//! # Running
+//!
+//! Point one of the environment variables below at a Postgres server —
+//! the URL names the maintenance database used to create and drop the
+//! per-test ones:
+//!
+//! | Variable | Precedence |
+//! |----------|------------|
+//! | `ENTITY_DERIVE_TEST_DATABASE_URL` | preferred |
+//! | `DATABASE_URL` | fallback |
+//!
+//! ```text
+//! ENTITY_DERIVE_TEST_DATABASE_URL=postgres://postgres@localhost/postgres \
+//!   cargo test -p entity-derive --all-features --test postgres
+//! ```
+//!
+//! With neither variable set the cases print a notice and pass, so a
+//! contributor without a local server is not blocked. Under CI the
+//! absence is a hard error instead — coverage must not be lost by a
+//! forgotten variable.
+//!
+//! # Isolation
+//!
+//! Table names are compile-time constants, so isolation comes from a
+//! database per test rather than a schema per test. Names carry their
+//! creation timestamp (`ed_t_<millis>_<random>_<label>`), which lets
+//! every run sweep databases left behind by an earlier *aborted* run
+//! without ever touching one belonging to a test running right now.
+
+use std::{
+    env,
+    time::{SystemTime, UNIX_EPOCH}
+};
+
+use sqlx::{
+    AssertSqlSafe, Connection, PgConnection, PgPool,
+    postgres::{PgConnectOptions, PgPoolOptions}
+};
+use uuid::Uuid;
+
+/// Environment variables consulted for the maintenance connection, in
+/// order of precedence.
+const URL_VARS: [&str; 2] = ["ENTITY_DERIVE_TEST_DATABASE_URL", "DATABASE_URL"];
+
+/// Prefix shared by every database this harness creates.
+const DB_PREFIX: &str = "ed_t_";
+
+/// Age past which a leftover database is treated as abandoned by an
+/// aborted run and swept.
+const STALE_AFTER_MS: u128 = 30 * 60 * 1000;
+
+/// A provisioned database, owned by exactly one test.
+pub struct TestDb {
+    /// Name of the database created for this test.
+    name:  String,
+    /// Pool connected to that database.
+    pool:  PgPool,
+    /// Connection options of the maintenance database, used to create
+    /// and drop `name`.
+    admin: PgConnectOptions
+}
+
+impl TestDb {
+    /// Pool connected to the throwaway database.
+    pub const fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Execute arbitrary SQL against the throwaway database.
+    ///
+    /// Accepts multi-statement scripts, which is what the generated
+    /// `MIGRATION_UP` and `MIGRATION_DOWN` constants are.
+    pub async fn run(&self, sql: &str) {
+        sqlx::raw_sql(AssertSqlSafe(sql.to_owned()))
+            .execute(&self.pool)
+            .await
+            .unwrap_or_else(|e| panic!("failed to run SQL against {}: {e}\n{sql}", self.name));
+    }
+
+    /// Close the pool and drop the database.
+    ///
+    /// Call this at the end of a test. A test that panics earlier
+    /// leaves the database behind on purpose — it can be inspected,
+    /// and the next run sweeps it once it ages out.
+    pub async fn teardown(self) {
+        self.pool.close().await;
+        let Ok(mut conn) = PgConnection::connect_with(&self.admin).await else {
+            return;
+        };
+        let drop_sql = format!("DROP DATABASE IF EXISTS \"{}\" WITH (FORCE)", self.name);
+        let _ = sqlx::raw_sql(AssertSqlSafe(drop_sql))
+            .execute(&mut conn)
+            .await;
+    }
+}
+
+/// Provision a database for one test and apply the given migration
+/// scripts, or return `None` when no server is configured.
+///
+/// `label` is embedded in the database name to make a leftover
+/// identifiable.
+pub async fn provision(label: &str, migrations: &[&str]) -> Option<TestDb> {
+    let base = maintenance_url()?;
+    let admin: PgConnectOptions = base
+        .parse()
+        .unwrap_or_else(|e| panic!("invalid Postgres URL in the environment: {e}"));
+
+    sweep_abandoned(&admin).await;
+
+    let name = database_name(label);
+    let mut conn = PgConnection::connect_with(&admin)
+        .await
+        .unwrap_or_else(|e| panic!("cannot reach the Postgres server: {e}"));
+    let create_sql = format!("CREATE DATABASE \"{name}\"");
+    sqlx::raw_sql(AssertSqlSafe(create_sql))
+        .execute(&mut conn)
+        .await
+        .unwrap_or_else(|e| panic!("cannot create database {name}: {e}"));
+    let _ = conn.close().await;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect_with(admin.clone().database(&name))
+        .await
+        .unwrap_or_else(|e| panic!("cannot connect to {name}: {e}"));
+
+    let db = TestDb {
+        name,
+        pool,
+        admin
+    };
+    for script in migrations {
+        db.run(script).await;
+    }
+    Some(db)
+}
+
+/// Resolve the maintenance URL, deciding between skipping and failing
+/// when none is configured.
+fn maintenance_url() -> Option<String> {
+    for key in URL_VARS {
+        if let Ok(value) = env::var(key)
+            && !value.trim().is_empty()
+        {
+            return Some(value);
+        }
+    }
+
+    assert!(
+        env::var("CI").is_err(),
+        "the live-Postgres suite requires {} under CI; the job must provide a server",
+        URL_VARS.join(" or ")
+    );
+
+    eprintln!(
+        "skipping: no live Postgres configured, set {} to run this test",
+        URL_VARS.join(" or ")
+    );
+    None
+}
+
+/// Build a unique, timestamped database name for one test.
+fn database_name(label: &str) -> String {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis());
+    let slug: String = label
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .take(16)
+        .collect();
+    let salt = Uuid::new_v4().simple().to_string();
+    format!("{DB_PREFIX}{millis}_{}_{slug}", &salt[..8])
+}
+
+/// Drop databases this harness created that are older than
+/// [`STALE_AFTER_MS`], i.e. left behind by an aborted run.
+///
+/// Every failure is ignored: a sweep is a courtesy, never a reason to
+/// fail the test that triggered it.
+async fn sweep_abandoned(admin: &PgConnectOptions) {
+    let Ok(mut conn) = PgConnection::connect_with(admin).await else {
+        return;
+    };
+    let listed: Result<Vec<(String,)>, _> =
+        sqlx::query_as("SELECT datname FROM pg_database WHERE datname LIKE $1")
+            .bind(format!("{DB_PREFIX}%"))
+            .fetch_all(&mut conn)
+            .await;
+    let Ok(rows) = listed else {
+        return;
+    };
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_or(0, |d| d.as_millis());
+    for (name,) in rows {
+        let abandoned = created_at_millis(&name)
+            .is_some_and(|created| now.saturating_sub(created) > STALE_AFTER_MS);
+        if abandoned {
+            let drop_sql = format!("DROP DATABASE IF EXISTS \"{name}\" WITH (FORCE)");
+            let _ = sqlx::raw_sql(AssertSqlSafe(drop_sql))
+                .execute(&mut conn)
+                .await;
+        }
+    }
+    let _ = conn.close().await;
+}
+
+/// Recover the creation timestamp encoded in a harness database name.
+fn created_at_millis(name: &str) -> Option<u128> {
+    name.strip_prefix(DB_PREFIX)?
+        .split('_')
+        .next()?
+        .parse()
+        .ok()
+}

--- a/crates/entity-derive/tests/postgres.rs
+++ b/crates/entity-derive/tests/postgres.rs
@@ -1,0 +1,550 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Generated SQL executed against a live Postgres server.
+//!
+//! The trybuild cases in `tests/cases` prove that the macro emits code
+//! that compiles; nothing there proves that the emitted *SQL* is valid.
+//! This target closes that gap: the generated DDL creates real tables
+//! and the generated repository methods run real statements against
+//! them.
+//!
+//! Each entity lives in its own module so that the repository traits —
+//! all of which are implemented for `sqlx::PgPool` — never collide in
+//! method resolution.
+//!
+//! See [`pg`] for how to point the suite at a server; without one every
+//! case reports a skip and passes.
+
+mod pg;
+
+/// CRUD, bulk, keyset pagination, upsert, projections, filtering and
+/// schema assertion over a single richly annotated entity.
+mod articles {
+    use chrono::{DateTime, Utc};
+    use entity_derive::Entity;
+    use uuid::Uuid;
+
+    use crate::pg;
+
+    #[derive(Debug, Clone, Entity)]
+    #[entity(table = "articles", migrations, upsert(conflict = "slug"))]
+    #[projection(Card: id, title, views)]
+    pub struct Article {
+        #[id]
+        pub id: Uuid,
+
+        #[field(create, update, response)]
+        #[sort]
+        #[filter(like)]
+        pub title: String,
+
+        #[field(create, response)]
+        #[column(unique)]
+        pub slug: String,
+
+        #[field(create, response)]
+        pub body: String,
+
+        #[field(create, update, response)]
+        #[sort]
+        #[filter(range)]
+        pub views: i64,
+
+        /// Populated by the database default: the generated INSERT skips
+        /// `#[auto]` columns, so the DDL has to supply the value.
+        #[field(response)]
+        #[auto]
+        #[column(default = "NOW()")]
+        pub created_at: DateTime<Utc>
+    }
+
+    /// Build a create request with distinct values per call.
+    fn draft(slug: &str, title: &str, views: i64) -> CreateArticleRequest {
+        CreateArticleRequest {
+            title: title.to_owned(),
+            slug: slug.to_owned(),
+            body: format!("body of {slug}"),
+            views
+        }
+    }
+
+    #[tokio::test]
+    async fn crud_roundtrip() {
+        let Some(db) = pg::provision("crud", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let created = pool
+            .create(draft("hello", "Hello", 1))
+            .await
+            .expect("create failed");
+        assert_eq!(created.title, "Hello");
+        assert_eq!(created.views, 1);
+
+        let found = pool
+            .find_by_id(created.id)
+            .await
+            .expect("find_by_id failed")
+            .expect("row missing right after create");
+        assert_eq!(found.slug, "hello");
+        assert_eq!(
+            found.created_at, created.created_at,
+            "the auto column must come back from the database, not from the DTO"
+        );
+
+        let updated = pool
+            .update(
+                created.id,
+                UpdateArticleRequest {
+                    title: Some("Hello again".to_owned()),
+                    views: Some(7)
+                }
+            )
+            .await
+            .expect("update failed");
+        assert_eq!(updated.title, "Hello again");
+        assert_eq!(updated.views, 7);
+        assert_eq!(updated.body, created.body, "update must not touch body");
+
+        let listed = pool.list(10, 0).await.expect("list failed");
+        assert_eq!(listed.len(), 1);
+
+        assert!(pool.delete(created.id).await.expect("delete failed"));
+        assert!(
+            pool.find_by_id(created.id)
+                .await
+                .expect("find_by_id failed")
+                .is_none()
+        );
+
+        db.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn bulk_and_keyset_pagination() {
+        let Some(db) = pg::provision("bulk", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let created = pool
+            .create_many(vec![
+                draft("a", "A", 10),
+                draft("b", "B", 20),
+                draft("c", "C", 30),
+            ])
+            .await
+            .expect("create_many failed");
+        assert_eq!(created.len(), 3);
+
+        let ids: Vec<Uuid> = created.iter().map(|a| a.id).collect();
+        let fetched = pool
+            .find_by_ids(ids.clone())
+            .await
+            .expect("find_by_ids failed");
+        assert_eq!(fetched.len(), 3);
+
+        let first_page = pool.list_after(None, 2).await.expect("list_after failed");
+        assert_eq!(first_page.len(), 2);
+        let cursor = first_page.last().map(|a| a.id);
+        let second_page = pool
+            .list_after(cursor, 2)
+            .await
+            .expect("list_after with cursor failed");
+        assert_eq!(second_page.len(), 1);
+        assert!(
+            !second_page
+                .iter()
+                .any(|a| first_page.iter().any(|p| p.id == a.id)),
+            "keyset pages must not overlap"
+        );
+
+        let removed = pool.delete_many(ids).await.expect("delete_many failed");
+        assert_eq!(removed, 3);
+
+        db.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn upsert_touches_only_update_columns() {
+        let Some(db) = pg::provision("upsert", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let original = pool
+            .upsert(draft("guide", "Guide", 5))
+            .await
+            .expect("first upsert failed");
+
+        let mut conflicting = draft("guide", "Guide v2", 9);
+        conflicting.body = "rewritten body".to_owned();
+        let merged = pool
+            .upsert(conflicting)
+            .await
+            .expect("second upsert failed");
+
+        assert_eq!(
+            merged.id, original.id,
+            "conflict must reuse the existing row"
+        );
+        assert_eq!(merged.title, "Guide v2", "update-marked column must change");
+        assert_eq!(merged.views, 9, "update-marked column must change");
+        assert_eq!(
+            merged.body, original.body,
+            "column without #[field(update)] must survive the conflict"
+        );
+
+        db.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn query_filters_and_sorts() {
+        let Some(db) = pg::provision("query", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        pool.create_many(vec![
+            draft("rust-1", "Rust patterns", 100),
+            draft("rust-2", "Rust internals", 50),
+            draft("go-1", "Go patterns", 300),
+            draft("pct", "100% coverage", 1),
+        ])
+        .await
+        .expect("create_many failed");
+
+        let matched = pool
+            .query(ArticleQuery {
+                title: Some("rust".to_owned()),
+                sort: Some(ArticleSortField::ViewsDesc),
+                limit: Some(10),
+                ..Default::default()
+            })
+            .await
+            .expect("query failed");
+        assert_eq!(matched.len(), 2, "ILIKE filter must exclude the Go article");
+        assert_eq!(matched[0].views, 100, "sort must order by views descending");
+
+        let literal = pool
+            .query(ArticleQuery {
+                title: Some("100%".to_owned()),
+                ..Default::default()
+            })
+            .await
+            .expect("query with a wildcard character failed");
+        assert_eq!(
+            literal.len(),
+            1,
+            "a % inside the filter value must match literally, not as a wildcard"
+        );
+
+        let ranged = pool
+            .query(ArticleQuery {
+                views_from: Some(60),
+                ..Default::default()
+            })
+            .await
+            .expect("range query failed");
+        assert_eq!(ranged.len(), 2, "range filter must keep views >= 60");
+
+        let windowed = pool
+            .query(ArticleQuery {
+                views_from: Some(40),
+                views_to: Some(150),
+                ..Default::default()
+            })
+            .await
+            .expect("bounded range query failed");
+        assert_eq!(windowed.len(), 2, "both range bounds must apply");
+
+        db.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn projection_returns_subset() {
+        let Some(db) = pg::provision("projection", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let created = pool
+            .create(draft("card", "Card", 3))
+            .await
+            .expect("create failed");
+
+        let card: ArticleCard = pool
+            .find_by_id_card(created.id)
+            .await
+            .expect("find_by_id_card failed")
+            .expect("projection row missing");
+        assert_eq!(card.id, created.id);
+        assert_eq!(card.title, "Card");
+        assert_eq!(card.views, 3);
+
+        db.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn schema_assertion_detects_drift() {
+        let Some(db) = pg::provision("drift", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        Article::assert_schema(pool)
+            .await
+            .expect("freshly migrated table must match the entity");
+
+        db.run("ALTER TABLE articles DROP COLUMN body").await;
+        let drift = Article::assert_schema(pool)
+            .await
+            .expect_err("dropping a column must be reported as drift");
+        assert!(
+            drift.to_string().contains("body"),
+            "drift report must name the missing column, got: {drift}"
+        );
+
+        db.teardown().await;
+    }
+
+    #[tokio::test]
+    async fn migration_down_reverses_up() {
+        let Some(db) = pg::provision("migration", &[Article::MIGRATION_UP]).await else {
+            return;
+        };
+
+        Article::assert_schema(db.pool())
+            .await
+            .expect("MIGRATION_UP must create the declared table");
+
+        db.run(Article::MIGRATION_DOWN).await;
+        Article::assert_schema(db.pool())
+            .await
+            .expect_err("MIGRATION_DOWN must remove the table");
+
+        db.run(Article::MIGRATION_UP).await;
+        Article::assert_schema(db.pool())
+            .await
+            .expect("MIGRATION_UP must be repeatable after a down migration");
+
+        db.teardown().await;
+    }
+}
+
+/// Unique and case-insensitive lookup methods.
+mod accounts {
+    use entity_derive::Entity;
+    use uuid::Uuid;
+
+    use crate::pg;
+
+    #[derive(Debug, Clone, Entity)]
+    #[entity(table = "accounts", migrations)]
+    pub struct Account {
+        #[id]
+        pub id: Uuid,
+
+        #[field(create, response)]
+        #[column(unique, ci)]
+        pub email: String,
+
+        #[field(create, update, response)]
+        pub name: String
+    }
+
+    #[tokio::test]
+    async fn lookups_are_case_insensitive_when_declared() {
+        let Some(db) = pg::provision("lookup", &[Account::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let created = pool
+            .create(CreateAccountRequest {
+                email: "Ada@Example.COM".to_owned(),
+                name:  "Ada".to_owned()
+            })
+            .await
+            .expect("create failed");
+
+        let exact = pool
+            .find_by_email("Ada@Example.COM".to_owned())
+            .await
+            .expect("find_by_email failed")
+            .expect("row missing for the exact spelling");
+        assert_eq!(exact.id, created.id);
+
+        let folded = pool
+            .find_by_email("ada@example.com".to_owned())
+            .await
+            .expect("find_by_email failed")
+            .expect("ci column must match a differently cased spelling");
+        assert_eq!(folded.id, created.id);
+
+        assert!(
+            pool.exists_by_email("ADA@EXAMPLE.COM".to_owned())
+                .await
+                .expect("exists_by_email failed")
+        );
+
+        let duplicate = pool
+            .create(CreateAccountRequest {
+                email: "ADA@example.com".to_owned(),
+                name:  "Impostor".to_owned()
+            })
+            .await;
+        assert!(
+            duplicate.is_err(),
+            "the LOWER() unique index must reject a case variant"
+        );
+
+        db.teardown().await;
+    }
+}
+
+/// Soft-delete lifecycle: hidden reads, restore, hard delete.
+mod notes {
+    use chrono::{DateTime, Utc};
+    use entity_derive::Entity;
+    use uuid::Uuid;
+
+    use crate::pg;
+
+    #[derive(Debug, Clone, Entity)]
+    #[entity(table = "notes", soft_delete, migrations)]
+    pub struct Note {
+        #[id]
+        pub id: Uuid,
+
+        #[field(create, update, response)]
+        pub title: String,
+
+        #[field(skip)]
+        pub deleted_at: Option<DateTime<Utc>>
+    }
+
+    #[tokio::test]
+    async fn soft_delete_lifecycle() {
+        let Some(db) = pg::provision("softdelete", &[Note::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let note = pool
+            .create(CreateNoteRequest {
+                title: "Draft".to_owned()
+            })
+            .await
+            .expect("create failed");
+
+        assert!(pool.delete(note.id).await.expect("soft delete failed"));
+        assert!(
+            pool.find_by_id(note.id)
+                .await
+                .expect("find_by_id failed")
+                .is_none(),
+            "soft-deleted rows must be hidden from find_by_id"
+        );
+        assert!(
+            pool.list(10, 0).await.expect("list failed").is_empty(),
+            "soft-deleted rows must be hidden from list"
+        );
+        assert!(
+            pool.find_by_id_with_deleted(note.id)
+                .await
+                .expect("find_by_id_with_deleted failed")
+                .is_some(),
+            "the row must still exist physically"
+        );
+
+        assert!(pool.restore(note.id).await.expect("restore failed"));
+        assert!(
+            pool.find_by_id(note.id)
+                .await
+                .expect("find_by_id failed")
+                .is_some(),
+            "restore must bring the row back"
+        );
+
+        assert!(pool.hard_delete(note.id).await.expect("hard_delete failed"));
+        assert!(
+            pool.find_by_id_with_deleted(note.id)
+                .await
+                .expect("find_by_id_with_deleted failed")
+                .is_none(),
+            "hard_delete must remove the row"
+        );
+
+        db.teardown().await;
+    }
+}
+
+/// Optimistic locking via the `#[version]` column.
+mod orders {
+    use entity_derive::Entity;
+    use uuid::Uuid;
+
+    use crate::pg;
+
+    #[derive(Debug, Clone, Entity)]
+    #[entity(table = "orders", migrations)]
+    pub struct Order {
+        #[id]
+        pub id: Uuid,
+
+        #[field(create, update, response)]
+        pub note: String,
+
+        #[version]
+        #[field(response)]
+        #[auto]
+        pub version: i32
+    }
+
+    #[tokio::test]
+    async fn stale_version_is_rejected() {
+        let Some(db) = pg::provision("version", &[Order::MIGRATION_UP]).await else {
+            return;
+        };
+        let pool = db.pool();
+
+        let order = pool
+            .create(CreateOrderRequest {
+                note: "first".to_owned()
+            })
+            .await
+            .expect("create failed");
+        assert_eq!(order.version, 0, "a fresh row starts at version 0");
+
+        let bumped = pool
+            .update(
+                order.id,
+                UpdateOrderRequest {
+                    note:             Some("second".to_owned()),
+                    expected_version: order.version
+                }
+            )
+            .await
+            .expect("update with the current version must succeed");
+        assert_eq!(bumped.version, 1, "a successful update bumps the version");
+
+        let stale = pool
+            .update(
+                order.id,
+                UpdateOrderRequest {
+                    note:             Some("third".to_owned()),
+                    expected_version: order.version
+                }
+            )
+            .await;
+        assert!(
+            stale.is_err(),
+            "an update carrying a stale version must be rejected"
+        );
+
+        db.teardown().await;
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -16,12 +16,7 @@ all-features = true
 [advisories]
 version = 2
 db-path = "~/.cargo/advisory-db"
-ignore = [
-    # proc-macro-error2 is unmaintained, no safe upgrade available.
-    # Pulled transitively by validator_derive -> validator (dev-dependency only).
-    # https://github.com/GnomedDev/proc-macro-error-2/issues/17
-    "RUSTSEC-2026-0173",
-]
+ignore = []
 
 [licenses]
 version = 2


### PR DESCRIPTION
Closes #234

Adds a test target that executes the generated SQL against a real Postgres, plus the CI job that gates on it. Until now the suite proved only that the macro *compiles*: no generated statement had ever been sent to a server.

## Harness

`crates/entity-derive/tests/pg/mod.rs` provisions a throwaway database per test, applies the entity's generated `MIGRATION_UP`, and drops the database at the end.

| Behaviour | Detail |
|---|---|
| Server URL | `ENTITY_DERIVE_TEST_DATABASE_URL`, falling back to `DATABASE_URL` |
| No URL locally | prints a notice and passes, so contributors are not blocked |
| No URL under CI | hard error — coverage cannot be lost to a forgotten variable |
| Isolation | one database per test; table names are compile-time constants, so a schema per test is not an option |
| Leftovers | database names carry their creation time; each run drops only harness databases older than 30 minutes, never one belonging to a test running right now |

## Covered

`crates/entity-derive/tests/postgres.rs`, one module per entity so the repository traits (all implemented for `PgPool`) do not collide in method resolution:

| Test | Generated code exercised |
|---|---|
| `crud_roundtrip` | create, find_by_id, update, list, delete, auto column round-trip |
| `bulk_and_keyset_pagination` | create_many, find_by_ids, list_after cursor paging, delete_many |
| `upsert_touches_only_update_columns` | ON CONFLICT reuses the row, updates only `#[field(update)]` columns |
| `query_filters_and_sorts` | ILIKE filter, wildcard escaping, both range bounds, whitelisted ORDER BY |
| `projection_returns_subset` | `find_by_id_card` |
| `schema_assertion_detects_drift` | `assert_schema` clean after migration, reports the column dropped behind its back |
| `migration_down_reverses_up` | `MIGRATION_DOWN` removes the table, `MIGRATION_UP` is repeatable afterwards |
| `lookups_are_case_insensitive_when_declared` | `find_by_email` / `exists_by_email` over a `column(unique, ci)` column, and the `LOWER()` unique index rejecting a case variant |
| `soft_delete_lifecycle` | soft delete hides the row from reads, `find_by_id_with_deleted`, restore, hard_delete |
| `stale_version_is_rejected` | `#[version]` bumps on success and rejects a stale `expected_version` |

## CI

New `postgres` job over a service-container matrix (Postgres 18 and 17), running in parallel with the existing test job. The two jobs without a server (`test`, `coverage`) exclude the target with `-E 'not binary(postgres)'`.

## Found on the first run

`#[auto]` timestamp columns are emitted as `NOT NULL` with no `DEFAULT`, while the generated INSERT skips `#[auto]` columns — every `create()` against a table built from `MIGRATION_UP` fails with `23502`. The suite here declares `#[column(default = "NOW()")]` to stay green; the defect is tracked separately and its fix will drop that workaround as the regression test.

## Also

`cargo update` moved `validator_derive` onto `proc-macro-error3`, so the `RUSTSEC-2026-0173` ignore in `deny.toml` no longer matches anything and is removed. `cargo deny check` is clean on advisories, bans, licenses and sources.
