### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...HEAD)
 
+## [0.22.7](https://github.com/RAprogramm/entity-derive/compare/v0.22.6...v0.22.7) - 2026-07-27
+
+### ✨ Features
+
+- OpenAPI schema overrides carried to generated structs ([#291](https://github.com/RAprogramm/entity-derive/issues/291))
+- repository wrapper invoking the generated hooks ([#267](https://github.com/RAprogramm/entity-derive/issues/267))
+- domain operations writing declared columns ([#266](https://github.com/RAprogramm/entity-derive/issues/266))
+- participant scopes over an OR group of columns ([#265](https://github.com/RAprogramm/entity-derive/issues/265))
+- chainable setters on update DTOs ([#264](https://github.com/RAprogramm/entity-derive/issues/264))
+
+### 🐛 Bug Fixes
+
+- reject SQL identifiers that generated statements cannot carry ([#249](https://github.com/RAprogramm/entity-derive/issues/249))
+- reach the runtime through the facade in generated code ([#247](https://github.com/RAprogramm/entity-derive/issues/247))
+- give auto temporal columns a database default in migrations ([#238](https://github.com/RAprogramm/entity-derive/issues/238))
+
+### 📚 Documentation
+
+- security, support and conduct policies ([#274](https://github.com/RAprogramm/entity-derive/issues/274))
+- mark the ClickHouse and MongoDB dialects as unimplemented ([#251](https://github.com/RAprogramm/entity-derive/issues/251))
+- pass bare substrings to like filters in every example ([#245](https://github.com/RAprogramm/entity-derive/issues/245))
+
+### 🧪 Testing
+
+- execute commands, guards, transitions and the OpenAPI document ([#263](https://github.com/RAprogramm/entity-derive/issues/263))
+- drive the generated HTTP handlers over a real router ([#260](https://github.com/RAprogramm/entity-derive/issues/260))
+- execute join views, the policy wrapper, the drainer and the subscriber ([#258](https://github.com/RAprogramm/entity-derive/issues/258))
+- execute the remaining generated SQL surfaces against Postgres ([#255](https://github.com/RAprogramm/entity-derive/issues/255))
+- execute generated SQL against a live Postgres ([#235](https://github.com/RAprogramm/entity-derive/issues/235))
+
 ## [0.22.6](https://github.com/RAprogramm/entity-derive/compare/v0.22.5...v0.22.6) - 2026-07-21
 
 ### ✨ Features

--- a/crates/entity-core/CHANGELOG.md
+++ b/crates/entity-core/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.4](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.3...entity-core-v0.10.4) - 2026-07-27
+
+### 🐛 Bug Fixes
+
+- reach the runtime through the facade in generated code ([#247](https://github.com/RAprogramm/entity-derive/issues/247))
+
+### 🧪 Testing
+
+- execute commands, guards, transitions and the OpenAPI document ([#263](https://github.com/RAprogramm/entity-derive/issues/263))
+- execute the remaining generated SQL surfaces against Postgres ([#255](https://github.com/RAprogramm/entity-derive/issues/255))
+
 ## [0.10.3](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.2...entity-core-v0.10.3) - 2026-07-21
 
 ### 🐛 Bug Fixes

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-core"
-version = "0.10.3"
+version = "0.10.4"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.16](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.15...entity-derive-impl-v0.20.16) - 2026-07-27
+
+### ⚙️ CI
+
+- gate feature combinations, dependency policy and semver ([#248](https://github.com/RAprogramm/entity-derive/issues/248))
+
+### ✨ Features
+
+- OpenAPI schema overrides carried to generated structs ([#291](https://github.com/RAprogramm/entity-derive/issues/291))
+- repository wrapper invoking the generated hooks ([#267](https://github.com/RAprogramm/entity-derive/issues/267))
+- domain operations writing declared columns ([#266](https://github.com/RAprogramm/entity-derive/issues/266))
+- participant scopes over an OR group of columns ([#265](https://github.com/RAprogramm/entity-derive/issues/265))
+- chainable setters on update DTOs ([#264](https://github.com/RAprogramm/entity-derive/issues/264))
+
+### 🐛 Bug Fixes
+
+- gate the token budget on the SQL generator ([#286](https://github.com/RAprogramm/entity-derive/issues/286))
+- reject SQL identifiers that generated statements cannot carry ([#249](https://github.com/RAprogramm/entity-derive/issues/249))
+- reach the runtime through the facade in generated code ([#247](https://github.com/RAprogramm/entity-derive/issues/247))
+- give auto temporal columns a database default in migrations ([#238](https://github.com/RAprogramm/entity-derive/issues/238))
+
+### 📚 Documentation
+
+- mark the ClickHouse and MongoDB dialects as unimplemented ([#251](https://github.com/RAprogramm/entity-derive/issues/251))
+
+### 🧪 Testing
+
+- execute commands, guards, transitions and the OpenAPI document ([#263](https://github.com/RAprogramm/entity-derive/issues/263))
+- execute the remaining generated SQL surfaces against Postgres ([#255](https://github.com/RAprogramm/entity-derive/issues/255))
+- budget the size of the generated token stream ([#252](https://github.com/RAprogramm/entity-derive/issues/252))
+
 ## [0.20.15](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.14...entity-derive-impl-v0.20.15) - 2026-07-21
 
 ### ✨ Features

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.15"
+version = "0.20.16"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.22.6"
+version = "0.22.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-core`: 0.10.3 -> 0.10.4 (✓ API compatible changes)
* `entity-derive-impl`: 0.20.15 -> 0.20.16
* `entity-derive`: 0.22.6 -> 0.22.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-core`

<blockquote>

## [0.10.4](https://github.com/RAprogramm/entity-derive/compare/entity-core-v0.10.3...entity-core-v0.10.4) - 2026-07-27

### 🐛 Bug Fixes

- reach the runtime through the facade in generated code ([#247](https://github.com/RAprogramm/entity-derive/issues/247))

### 🧪 Testing

- execute commands, guards, transitions and the OpenAPI document ([#263](https://github.com/RAprogramm/entity-derive/issues/263))
- execute the remaining generated SQL surfaces against Postgres ([#255](https://github.com/RAprogramm/entity-derive/issues/255))
</blockquote>

## `entity-derive-impl`

<blockquote>

## [0.20.16](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.15...entity-derive-impl-v0.20.16) - 2026-07-27

### ⚙️ CI

- gate feature combinations, dependency policy and semver ([#248](https://github.com/RAprogramm/entity-derive/issues/248))

### ✨ Features

- OpenAPI schema overrides carried to generated structs ([#291](https://github.com/RAprogramm/entity-derive/issues/291))
- repository wrapper invoking the generated hooks ([#267](https://github.com/RAprogramm/entity-derive/issues/267))
- domain operations writing declared columns ([#266](https://github.com/RAprogramm/entity-derive/issues/266))
- participant scopes over an OR group of columns ([#265](https://github.com/RAprogramm/entity-derive/issues/265))
- chainable setters on update DTOs ([#264](https://github.com/RAprogramm/entity-derive/issues/264))

### 🐛 Bug Fixes

- gate the token budget on the SQL generator ([#286](https://github.com/RAprogramm/entity-derive/issues/286))
- reject SQL identifiers that generated statements cannot carry ([#249](https://github.com/RAprogramm/entity-derive/issues/249))
- reach the runtime through the facade in generated code ([#247](https://github.com/RAprogramm/entity-derive/issues/247))
- give auto temporal columns a database default in migrations ([#238](https://github.com/RAprogramm/entity-derive/issues/238))

### 📚 Documentation

- mark the ClickHouse and MongoDB dialects as unimplemented ([#251](https://github.com/RAprogramm/entity-derive/issues/251))

### 🧪 Testing

- execute commands, guards, transitions and the OpenAPI document ([#263](https://github.com/RAprogramm/entity-derive/issues/263))
- execute the remaining generated SQL surfaces against Postgres ([#255](https://github.com/RAprogramm/entity-derive/issues/255))
- budget the size of the generated token stream ([#252](https://github.com/RAprogramm/entity-derive/issues/252))
</blockquote>

## `entity-derive`

<blockquote>


## [0.22.7](https://github.com/RAprogramm/entity-derive/compare/v0.22.6...v0.22.7) - 2026-07-27

### ✨ Features

- OpenAPI schema overrides carried to generated structs ([#291](https://github.com/RAprogramm/entity-derive/issues/291))
- repository wrapper invoking the generated hooks ([#267](https://github.com/RAprogramm/entity-derive/issues/267))
- domain operations writing declared columns ([#266](https://github.com/RAprogramm/entity-derive/issues/266))
- participant scopes over an OR group of columns ([#265](https://github.com/RAprogramm/entity-derive/issues/265))
- chainable setters on update DTOs ([#264](https://github.com/RAprogramm/entity-derive/issues/264))

### 🐛 Bug Fixes

- reject SQL identifiers that generated statements cannot carry ([#249](https://github.com/RAprogramm/entity-derive/issues/249))
- reach the runtime through the facade in generated code ([#247](https://github.com/RAprogramm/entity-derive/issues/247))
- give auto temporal columns a database default in migrations ([#238](https://github.com/RAprogramm/entity-derive/issues/238))

### 📚 Documentation

- security, support and conduct policies ([#274](https://github.com/RAprogramm/entity-derive/issues/274))
- mark the ClickHouse and MongoDB dialects as unimplemented ([#251](https://github.com/RAprogramm/entity-derive/issues/251))
- pass bare substrings to like filters in every example ([#245](https://github.com/RAprogramm/entity-derive/issues/245))

### 🧪 Testing

- execute commands, guards, transitions and the OpenAPI document ([#263](https://github.com/RAprogramm/entity-derive/issues/263))
- drive the generated HTTP handlers over a real router ([#260](https://github.com/RAprogramm/entity-derive/issues/260))
- execute join views, the policy wrapper, the drainer and the subscriber ([#258](https://github.com/RAprogramm/entity-derive/issues/258))
- execute the remaining generated SQL surfaces against Postgres ([#255](https://github.com/RAprogramm/entity-derive/issues/255))
- execute generated SQL against a live Postgres ([#235](https://github.com/RAprogramm/entity-derive/issues/235))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).