### PR TITLE
#239 docs: pass bare substrings to like filters in every example

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ tracing-subscriber = "0.3"
 #[field(response)]             // Include in Response
 #[field(skip)]                 // Exclude from all DTOs
 #[filter]                      // Exact match filter
-#[filter(like)]                // ILIKE pattern filter
+#[filter(like)]                // ILIKE substring filter; pass the bare value, wildcards in it are escaped
 #[filter(range)]               // Range filter (from/to)
 #[filter(search)]              // Trigram substring search (pg_trgm)
 #[sort]                        // Whitelisted dynamic ORDER BY
@@ -397,7 +397,9 @@ the flag behavior is unchanged.
 `#[filter(search)]` on a text column gives the Query struct a fuzzy
 substring filter (`col ILIKE '%' || $n || '%'`), while `migrations`
 emit the matching `gin_trgm_ops` index and add `pg_trgm` to
-`MIGRATION_EXTENSIONS` automatically:
+`MIGRATION_EXTENSIONS` automatically. Unlike `#[filter(like)]`, the
+value is bound as given: a `%` inside it acts as a wildcard rather than
+matching literally.
 
 ```rust,ignore
 #[field(create, update, response)]

--- a/crates/entity-derive/tests/cases/pass/sort_keyset.rs
+++ b/crates/entity-derive/tests/cases/pass/sort_keyset.rs
@@ -22,7 +22,7 @@ pub struct Post {
 
 async fn exercise(pool: sqlx::PgPool, cursor: Option<Uuid>) -> Result<(), sqlx::Error> {
     let query = PostQuery {
-        title: Some("%rust%".into()),
+        title: Some("rust".into()),
         sort: Some(PostSortField::ViewsDesc),
         limit: Some(20),
         ..Default::default()

--- a/wiki/Filtering-en.md
+++ b/wiki/Filtering-en.md
@@ -148,13 +148,21 @@ WHERE name ILIKE $1
 ```
 
 **Usage:**
+
+Pass the bare substring. The generated code wraps the value in `%...%`
+itself and escapes any `%`, `_` or `\` it contains, so a wildcard typed
+by an end user matches literally instead of widening the search:
+
 ```rust
 let query = ProductQuery {
-    name: Some("%widget%".into()),  // Contains "widget"
-    description: Some("premium%".into()),  // Starts with "premium"
+    name: Some("widget".into()),          // Contains "widget"
+    description: Some("premium".into()),  // Contains "premium"
     ..Default::default()
 };
 ```
+
+Every `like` filter is a substring match: prefix- or suffix-only
+matching is not expressible through it.
 
 ### Range Filter (`#[filter(range)]`)
 
@@ -215,7 +223,7 @@ let query = ProductQuery {
     category_id: Some(electronics_category_id),
     price_from: Some(0),
     price_to: Some(10000),  // $100.00
-    name: Some("%phone%".into()),
+    name: Some("phone".into()),
     limit: Some(50),
     ..Default::default()
 };
@@ -260,7 +268,7 @@ async fn list_products(
     let per_page = params.per_page.unwrap_or(20).min(100);
 
     let query = ProductQuery {
-        name: params.name.map(|n| format!("%{}%", n)),
+        name: params.name,
         category_id: params.category_id,
         price_from: params.min_price,
         price_to: params.max_price,
@@ -405,7 +413,7 @@ let next: Vec<Post> = pool.list_after(page.last().map(|p| p.id), 20).await?;
 
 ## Trigram Search
 
-`#[filter(search)]` on a text column adds a fuzzy substring filter (`col ILIKE '%' || $n || '%'`, the term is bound). With `migrations`, the matching `gin_trgm_ops` index lands in `MIGRATION_UP` and `pg_trgm` is added to `MIGRATION_EXTENSIONS` automatically. Compile-time check: the field must be a `String`.
+`#[filter(search)]` on a text column adds a fuzzy substring filter (`col ILIKE '%' || $n || '%'`; the term is bound as given, so a `%` inside it acts as a wildcard rather than matching literally, unlike `#[filter(like)]`). With `migrations`, the matching `gin_trgm_ops` index lands in `MIGRATION_UP` and `pg_trgm` is added to `MIGRATION_EXTENSIONS` automatically. Compile-time check: the field must be a `String`.
 
 ```rust
 #[field(create, update, response)]

--- a/wiki/Filtrado.md
+++ b/wiki/Filtrado.md
@@ -148,13 +148,22 @@ WHERE name ILIKE $1
 ```
 
 **Uso:**
+
+Pase la subcadena sin comodines. El código generado envuelve el valor en
+`%...%` y escapa los `%`, `_` y `\` que contenga, de modo que un comodín
+escrito por el usuario final coincide literalmente en lugar de ampliar
+la búsqueda:
+
 ```rust
 let query = ProductQuery {
-    name: Some("%widget%".into()),  // Contiene "widget"
-    description: Some("premium%".into()),  // Empieza con "premium"
+    name: Some("widget".into()),          // Contiene "widget"
+    description: Some("premium".into()),  // Contiene "premium"
     ..Default::default()
 };
 ```
+
+Todo filtro `like` es una coincidencia de subcadena: buscar solo por
+prefijo o solo por sufijo no se puede expresar con él.
 
 ### Filtro de Rango (`#[filter(range)]`)
 
@@ -215,7 +224,7 @@ let query = ProductQuery {
     category_id: Some(electronics_category_id),
     price_from: Some(0),
     price_to: Some(10000),  // $100.00
-    name: Some("%phone%".into()),
+    name: Some("phone".into()),
     limit: Some(50),
     ..Default::default()
 };
@@ -260,7 +269,7 @@ async fn list_products(
     let per_page = params.per_page.unwrap_or(20).min(100);
 
     let query = ProductQuery {
-        name: params.name.map(|n| format!("%{}%", n)),
+        name: params.name,
         category_id: params.category_id,
         price_from: params.min_price,
         price_to: params.max_price,
@@ -405,7 +414,7 @@ let next: Vec<Post> = pool.list_after(page.last().map(|p| p.id), 20).await?;
 
 ## Búsqueda por trigramas
 
-`#[filter(search)]` en una columna de texto añade un filtro difuso de subcadena (`col ILIKE '%' || $n || '%'`, el término va ligado). Con `migrations`, el índice `gin_trgm_ops` correspondiente aterriza en `MIGRATION_UP` y `pg_trgm` se añade automáticamente a `MIGRATION_EXTENSIONS`. Verificación en compilación: el campo debe ser `String`.
+`#[filter(search)]` en una columna de texto añade un filtro difuso de subcadena (`col ILIKE '%' || $n || '%'`; el término va ligado tal cual, por lo que un `%` dentro de él actúa como comodín en lugar de coincidir literalmente, a diferencia de `#[filter(like)]`). Con `migrations`, el índice `gin_trgm_ops` correspondiente aterriza en `MIGRATION_UP` y `pg_trgm` se añade automáticamente a `MIGRATION_EXTENSIONS`. Verificación en compilación: el campo debe ser `String`.
 
 ```rust
 #[field(create, update, response)]

--- a/wiki/Relaciones.md
+++ b/wiki/Relaciones.md
@@ -354,7 +354,7 @@ pub struct Post {
 // Obtener posts de un usuario específico con filtro de título
 let query = PostQuery {
     user_id: Some(user_id),
-    title: Some("%rust%".into()),
+    title: Some("rust".into()),
     limit: Some(20),
     ..Default::default()
 };

--- a/wiki/Relations-en.md
+++ b/wiki/Relations-en.md
@@ -405,7 +405,7 @@ pub struct Post {
 // Get posts by specific user with title filter
 let query = PostQuery {
     user_id: Some(user_id),
-    title: Some("%rust%".into()),
+    title: Some("rust".into()),
     limit: Some(20),
     ..Default::default()
 };

--- a/wiki/Связи.md
+++ b/wiki/Связи.md
@@ -383,7 +383,7 @@ pub struct Post {
 // Получение постов конкретного пользователя с фильтром по заголовку
 let query = PostQuery {
     user_id: Some(user_id),
-    title: Some("%rust%".into()),
+    title: Some("rust".into()),
     limit: Some(20),
     ..Default::default()
 };

--- a/wiki/Фильтрация.md
+++ b/wiki/Фильтрация.md
@@ -148,13 +148,22 @@ WHERE name ILIKE $1
 ```
 
 **Использование:**
+
+Передавайте чистую подстроку. Генерируемый код сам оборачивает значение
+в `%...%` и экранирует находящиеся в нём `%`, `_` и `\`, поэтому
+подстановочный знак, введённый пользователем, ищется буквально и не
+расширяет выборку:
+
 ```rust
 let query = ProductQuery {
-    name: Some("%widget%".into()),  // Содержит "widget"
-    description: Some("premium%".into()),  // Начинается с "premium"
+    name: Some("widget".into()),          // Содержит "widget"
+    description: Some("premium".into()),  // Содержит "premium"
     ..Default::default()
 };
 ```
+
+Любой фильтр `like` — это поиск подстроки: совпадение только по началу
+или только по концу строки через него не выражается.
 
 ### Фильтр по диапазону (`#[filter(range)]`)
 
@@ -215,7 +224,7 @@ let query = ProductQuery {
     category_id: Some(electronics_category_id),
     price_from: Some(0),
     price_to: Some(10000),  // $100.00
-    name: Some("%phone%".into()),
+    name: Some("phone".into()),
     limit: Some(50),
     ..Default::default()
 };
@@ -260,7 +269,7 @@ async fn list_products(
     let per_page = params.per_page.unwrap_or(20).min(100);
 
     let query = ProductQuery {
-        name: params.name.map(|n| format!("%{}%", n)),
+        name: params.name,
         category_id: params.category_id,
         price_from: params.min_price,
         price_to: params.max_price,
@@ -405,7 +414,7 @@ let next: Vec<Post> = pool.list_after(page.last().map(|p| p.id), 20).await?;
 
 ## Trigram-поиск
 
-`#[filter(search)]` на текстовой колонке добавляет нечёткий substring-фильтр (`col ILIKE '%' || $n || '%'`, термин биндится). При включённых `migrations` соответствующий индекс `gin_trgm_ops` попадает в `MIGRATION_UP`, а `pg_trgm` автоматически добавляется в `MIGRATION_EXTENSIONS`. Проверка на компиляции: поле должно быть `String`.
+`#[filter(search)]` на текстовой колонке добавляет нечёткий substring-фильтр (`col ILIKE '%' || $n || '%'`; термин биндится как есть, поэтому `%` внутри него работает как подстановочный знак, а не ищется буквально, в отличие от `#[filter(like)]`). При включённых `migrations` соответствующий индекс `gin_trgm_ops` попадает в `MIGRATION_UP`, а `pg_trgm` автоматически добавляется в `MIGRATION_EXTENSIONS`. Проверка на компиляции: поле должно быть `String`.
 
 ```rust
 #[field(create, update, response)]

--- a/wiki/关系.md
+++ b/wiki/关系.md
@@ -354,7 +354,7 @@ pub struct Post {
 // 获取特定用户的文章并按标题过滤
 let query = PostQuery {
     user_id: Some(user_id),
-    title: Some("%rust%".into()),
+    title: Some("rust".into()),
     limit: Some(20),
     ..Default::default()
 };

--- a/wiki/过滤.md
+++ b/wiki/过滤.md
@@ -148,13 +148,20 @@ WHERE name ILIKE $1
 ```
 
 **用法：**
+
+请传入不带通配符的子串。生成的代码会自行把值包进 `%...%`，并转义其中的
+`%`、`_` 和 `\`，因此最终用户输入的通配符会被按字面匹配，而不会扩大搜索
+范围：
+
 ```rust
 let query = ProductQuery {
-    name: Some("%widget%".into()),  // 包含 "widget"
-    description: Some("premium%".into()),  // 以 "premium" 开头
+    name: Some("widget".into()),          // 包含 "widget"
+    description: Some("premium".into()),  // 包含 "premium"
     ..Default::default()
 };
 ```
+
+每个 `like` 过滤器都是子串匹配：仅按前缀或仅按后缀匹配无法用它表达。
 
 ### 范围过滤 (`#[filter(range)]`)
 
@@ -215,7 +222,7 @@ let query = ProductQuery {
     category_id: Some(electronics_category_id),
     price_from: Some(0),
     price_to: Some(10000),  // $100.00
-    name: Some("%phone%".into()),
+    name: Some("phone".into()),
     limit: Some(50),
     ..Default::default()
 };
@@ -260,7 +267,7 @@ async fn list_products(
     let per_page = params.per_page.unwrap_or(20).min(100);
 
     let query = ProductQuery {
-        name: params.name.map(|n| format!("%{}%", n)),
+        name: params.name,
         category_id: params.category_id,
         price_from: params.min_price,
         price_to: params.max_price,
@@ -405,7 +412,7 @@ let next: Vec<Post> = pool.list_after(page.last().map(|p| p.id), 20).await?;
 
 ## 三元组搜索
 
-在文本列上使用 `#[filter(search)]` 会添加模糊子串过滤（`col ILIKE '%' || $n || '%'`，搜索词通过绑定传入）。启用 `migrations` 时，相应的 `gin_trgm_ops` 索引会进入 `MIGRATION_UP`，并且 `pg_trgm` 会自动加入 `MIGRATION_EXTENSIONS`。编译期检查：字段必须是 `String`。
+在文本列上使用 `#[filter(search)]` 会添加模糊子串过滤（`col ILIKE '%' || $n || '%'`；搜索词按原样绑定，因此其中的 `%` 会作为通配符生效，而不是按字面匹配，这与 `#[filter(like)]` 不同）。启用 `migrations` 时，相应的 `gin_trgm_ops` 索引会进入 `MIGRATION_UP`，并且 `pg_trgm` 会自动加入 `MIGRATION_EXTENSIONS`。编译期检查：字段必须是 `String`。
 
 ```rust
 #[field(create, update, response)]

--- a/wiki/관계.md
+++ b/wiki/관계.md
@@ -383,7 +383,7 @@ pub struct Post {
 // 제목 필터로 특정 사용자의 게시물 가져오기
 let query = PostQuery {
     user_id: Some(user_id),
-    title: Some("%rust%".into()),
+    title: Some("rust".into()),
     limit: Some(20),
     ..Default::default()
 };

--- a/wiki/필터링.md
+++ b/wiki/필터링.md
@@ -148,13 +148,21 @@ WHERE name ILIKE $1
 ```
 
 **사용법:**
+
+와일드카드 없이 부분 문자열만 전달하세요. 생성된 코드가 값을 `%...%`로
+감싸고 그 안의 `%`, `_`, `\`를 이스케이프하므로, 사용자가 입력한
+와일드카드는 검색 범위를 넓히지 않고 문자 그대로 매칭됩니다:
+
 ```rust
 let query = ProductQuery {
-    name: Some("%widget%".into()),  // "widget" 포함
-    description: Some("premium%".into()),  // "premium"으로 시작
+    name: Some("widget".into()),          // "widget" 포함
+    description: Some("premium".into()),  // "premium" 포함
     ..Default::default()
 };
 ```
+
+모든 `like` 필터는 부분 문자열 검색입니다. 접두사만 또는 접미사만
+매칭하는 것은 이 필터로 표현할 수 없습니다.
 
 ### 범위 필터 (`#[filter(range)]`)
 
@@ -215,7 +223,7 @@ let query = ProductQuery {
     category_id: Some(electronics_category_id),
     price_from: Some(0),
     price_to: Some(10000),  // $100.00
-    name: Some("%phone%".into()),
+    name: Some("phone".into()),
     limit: Some(50),
     ..Default::default()
 };
@@ -260,7 +268,7 @@ async fn list_products(
     let per_page = params.per_page.unwrap_or(20).min(100);
 
     let query = ProductQuery {
-        name: params.name.map(|n| format!("%{}%", n)),
+        name: params.name,
         category_id: params.category_id,
         price_from: params.min_price,
         price_to: params.max_price,
@@ -405,7 +413,7 @@ let next: Vec<Post> = pool.list_after(page.last().map(|p| p.id), 20).await?;
 
 ## 트라이그램 검색
 
-텍스트 컬럼의 `#[filter(search)]`는 퍼지 부분 문자열 필터(`col ILIKE '%' || $n || '%'`, 검색어는 바인딩됨)를 추가합니다. `migrations`가 켜져 있으면 해당 `gin_trgm_ops` 인덱스가 `MIGRATION_UP`에 포함되고 `pg_trgm`이 `MIGRATION_EXTENSIONS`에 자동 추가됩니다. 컴파일 타임 검사: 필드는 `String`이어야 합니다.
+텍스트 컬럼의 `#[filter(search)]`는 퍼지 부분 문자열 필터(`col ILIKE '%' || $n || '%'`; 검색어는 입력한 그대로 바인딩되므로 그 안의 `%`는 문자 그대로가 아니라 와일드카드로 동작합니다. `#[filter(like)]`와 다른 점입니다)를 추가합니다. `migrations`가 켜져 있으면 해당 `gin_trgm_ops` 인덱스가 `MIGRATION_UP`에 포함되고 `pg_trgm`이 `MIGRATION_EXTENSIONS`에 자동 추가됩니다. 컴파일 타임 검사: 필드는 `String`이어야 합니다.
 
 ```rust
 #[field(create, update, response)]


### PR DESCRIPTION
Closes #239

The generated `like` binding escapes `%`, `_` and `\\` in the value and wraps the result in `%...%`. Every documented example passed a value that already carried wildcards, so the documented call escaped them into literals and matched nothing.

- Filtering and relations pages in all five wiki languages now pass the bare substring, and the `like` section states that the macro adds the wildcards and escapes the ones the caller supplies.
- Added the note that `like` is always a substring match — prefix- or suffix-only matching is not expressible through it.
- The `sort_keyset` trybuild case stopped modelling the wrong call.
- README attribute reference says the same in one line.
- The difference from `search` — which binds the term as given, so a `%` there is a wildcard — is now stated in the README and in all five wiki pages.

The behaviour itself is already covered by the live-Postgres suite: `query_filters_and_sorts` asserts that a value containing `%` matches literally.