### PR TITLE
#246 fix: reach the runtime through the facade in generated code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,6 +229,37 @@ jobs:
           report_type: test_results
           fail_ci_if_error: false
 
+  examples:
+    name: Examples
+    needs: [check, fmt, security, reuse]
+    if: ${{ !inputs.skip_tests }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: examples
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      # The example crates are the only consumers shaped like a user
+      # project: they depend on the facade alone, so they are what
+      # proves the generated code needs nothing else in scope.
+      - name: Check every example
+        run: |
+          status=0
+          for manifest in examples/*/Cargo.toml; do
+            echo "::group::$manifest"
+            cargo check --manifest-path "$manifest" --all-targets || status=1
+            echo "::endgroup::"
+          done
+          exit $status
+
   postgres:
     name: Live Postgres (${{ matrix.postgres }})
     needs: [check, fmt, security, reuse]

--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ pub struct User {
 entity-derive = { version = "0.22", features = ["postgres", "api"] }
 ```
 
+Generated code reaches its own runtime through the `entity-derive`
+facade, so nothing else has to be added on its behalf. The crates you
+still declare are the ones your entity itself uses — the pool and column
+types, and `serde` when the DTOs are serialized:
+
+```toml
+sqlx = { version = "0.9", features = ["runtime-tokio", "postgres", "uuid", "chrono"] }
+uuid = { version = "1", features = ["v4", "v7", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+```
+
 ### Feature flags
 
 | Feature | Default | What it does |

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -43,6 +43,12 @@ pub mod transaction;
 
 /// Re-export `async_trait` for generated code.
 pub use async_trait::async_trait;
+/// Re-export `futures` for generated streaming methods.
+///
+/// Generated code reaches it through the `entity-derive` facade, so a
+/// consumer never has to depend on `futures` itself.
+#[cfg(feature = "streams")]
+pub use futures;
 
 /// Compare two strings in const context.
 ///

--- a/crates/entity-derive-impl/src/entity/commands/enum_gen.rs
+++ b/crates/entity-derive-impl/src/entity/commands/enum_gen.rs
@@ -17,8 +17,8 @@
 //!     Deactivate(DeactivateUser),
 //! }
 //!
-//! impl entity_core::EntityCommand for UserCommand {
-//!     fn kind(&self) -> entity_core::CommandKind { ... }
+//! impl ::entity_derive::EntityCommand for UserCommand {
+//!     fn kind(&self) -> ::entity_derive::CommandKind { ... }
 //!     fn name(&self) -> &'static str { ... }
 //! }
 //! ```
@@ -61,8 +61,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #variants
         }
 
-        impl entity_core::EntityCommand for #enum_name {
-            fn kind(&self) -> entity_core::CommandKind {
+        impl ::entity_derive::EntityCommand for #enum_name {
+            fn kind(&self) -> ::entity_derive::CommandKind {
                 match self {
                     #kind_arms
                 }
@@ -110,10 +110,10 @@ fn generate_kind_arms(commands: &[CommandDef]) -> TokenStream {
         .map(|cmd| {
             let variant_name = &cmd.name;
             let kind = match cmd.kind {
-                CommandKindHint::Create => quote! { entity_core::CommandKind::Create },
-                CommandKindHint::Update => quote! { entity_core::CommandKind::Update },
-                CommandKindHint::Delete => quote! { entity_core::CommandKind::Delete },
-                CommandKindHint::Custom => quote! { entity_core::CommandKind::Custom }
+                CommandKindHint::Create => quote! { ::entity_derive::CommandKind::Create },
+                CommandKindHint::Update => quote! { ::entity_derive::CommandKind::Update },
+                CommandKindHint::Delete => quote! { ::entity_derive::CommandKind::Delete },
+                CommandKindHint::Custom => quote! { ::entity_derive::CommandKind::Custom }
             };
 
             quote! {

--- a/crates/entity-derive-impl/src/entity/commands/handler_gen.rs
+++ b/crates/entity-derive-impl/src/entity/commands/handler_gen.rs
@@ -69,7 +69,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     quote! {
         #marker
         #[doc = #doc]
-        #[async_trait::async_trait]
+        #[::entity_derive::async_trait]
         #vis trait #trait_name: Send + Sync {
             /// Error type for handler operations.
             type Error: std::error::Error + Send + Sync;

--- a/crates/entity-derive-impl/src/entity/dto.rs
+++ b/crates/entity-derive-impl/src/entity/dto.rs
@@ -168,7 +168,7 @@ fn generate_update_dto(entity: &EntityDef) -> TokenStream {
                 #[serde(
                     default,
                     skip_serializing_if = "Option::is_none",
-                    with = "::entity_core::serde_helpers::double_option"
+                    with = "::entity_derive::serde_helpers::double_option"
                 )]
                 #garde
                 pub #n: Option<#t>

--- a/crates/entity-derive-impl/src/entity/events.rs
+++ b/crates/entity-derive-impl/src/entity/events.rs
@@ -19,10 +19,10 @@
 //!     Restored { id: Uuid },
 //! }
 //!
-//! impl entity_core::EntityEvent for UserEvent {
+//! impl ::entity_derive::EntityEvent for UserEvent {
 //!     type Id = Uuid;
 //!
-//!     fn kind(&self) -> entity_core::EventKind { ... }
+//!     fn kind(&self) -> ::entity_derive::EventKind { ... }
 //!     fn entity_id(&self) -> &Self::Id { ... }
 //! }
 //! ```
@@ -69,8 +69,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     let soft_delete_kind_arms = if entity.is_soft_delete() {
         quote! {
-            Self::SoftDeleted { .. } => entity_core::EventKind::SoftDeleted,
-            Self::Restored { .. } => entity_core::EventKind::Restored,
+            Self::SoftDeleted { .. } => ::entity_derive::EventKind::SoftDeleted,
+            Self::Restored { .. } => ::entity_derive::EventKind::Restored,
         }
     } else {
         TokenStream::new()
@@ -141,14 +141,14 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             }
         }
 
-        impl entity_core::EntityEvent for #event_name {
+        impl ::entity_derive::EntityEvent for #event_name {
             type Id = #id_type;
 
-            fn kind(&self) -> entity_core::EventKind {
+            fn kind(&self) -> ::entity_derive::EventKind {
                 match self {
-                    Self::Created(_) => entity_core::EventKind::Created,
-                    Self::Updated { .. } => entity_core::EventKind::Updated,
-                    Self::HardDeleted { .. } => entity_core::EventKind::HardDeleted,
+                    Self::Created(_) => ::entity_derive::EventKind::Created,
+                    Self::Updated { .. } => ::entity_derive::EventKind::Updated,
+                    Self::HardDeleted { .. } => ::entity_derive::EventKind::HardDeleted,
                     #soft_delete_kind_arms
                 }
             }

--- a/crates/entity-derive-impl/src/entity/hooks.rs
+++ b/crates/entity-derive-impl/src/entity/hooks.rs
@@ -122,7 +122,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         /// If a `before_*` hook returns an error, the caller should abort
         /// the operation. If an `after_*` hook returns an error, the
         /// operation has already completed but the error is propagated.
-        #[async_trait::async_trait]
+        #[::entity_derive::async_trait]
         #vis trait #hooks_trait: Send + Sync {
             /// Error type for hook operations.
             type Error: std::error::Error + Send + Sync;

--- a/crates/entity-derive-impl/src/entity/migrations/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres.rs
@@ -74,7 +74,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         .map(|(ty, declared)| {
             quote! {
                 assert!(
-                    ::entity_core::const_str_eq(<#ty>::PG_TYPE, #declared),
+                    ::entity_derive::const_str_eq(<#ty>::PG_TYPE, #declared),
                     "#[column(pg_enum = ...)] does not match the ValueObject's pg_type"
                 );
             }

--- a/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/attrs.rs
@@ -424,9 +424,9 @@ pub struct EntityAttrs {
     ///
     /// When enabled, generated write methods resolve violated
     /// constraint names against the entity's known constraints and
-    /// surface `entity_core::ConstraintError` through the repository
+    /// surface `::entity_derive::ConstraintError` through the repository
     /// `Error` type, which must additionally implement
-    /// `From<entity_core::ConstraintError>`.
+    /// `From<::entity_derive::ConstraintError>`.
     #[darling(default)]
     pub typed_constraints: bool
 }

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -178,7 +178,7 @@ impl EntityDef {
                 quote::ToTokens::to_token_stream(&attrs.error).to_string() == "sqlx :: Error";
             if default_error {
                 return Err(darling::Error::custom(
-                    "transition(...) requires a custom error type implementing From<entity_core::TransitionError>"
+                    "transition(...) requires a custom error type implementing From<::entity_derive::TransitionError>"
                 )
                 .with_span(&input.ident));
             }

--- a/crates/entity-derive-impl/src/entity/policy/allow_all.rs
+++ b/crates/entity-derive-impl/src/entity/policy/allow_all.rs
@@ -33,7 +33,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         #[derive(Debug, Clone, Copy, Default)]
         #vis struct #struct_name;
 
-        #[::entity_core::async_trait]
+        #[::entity_derive::async_trait]
         impl #trait_name for #struct_name {
             type Context = ();
             type Error = std::convert::Infallible;

--- a/crates/entity-derive-impl/src/entity/policy/trait_gen.rs
+++ b/crates/entity-derive-impl/src/entity/policy/trait_gen.rs
@@ -31,7 +31,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
     quote! {
         #marker
         #[doc = #doc]
-        #[::entity_core::async_trait]
+        #[::entity_derive::async_trait]
         #vis trait #trait_name: Send + Sync {
             /// Authorization context type (e.g., user session, request context).
             type Context: Send + Sync;

--- a/crates/entity-derive-impl/src/entity/policy/wrapper_gen.rs
+++ b/crates/entity-derive-impl/src/entity/policy/wrapper_gen.rs
@@ -66,15 +66,15 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
                 &self,
                 dto: #create_dto,
                 ctx: &P::Context,
-            ) -> Result<#entity_name, ::entity_core::policy::PolicyError<R::Error, P::Error>> {
+            ) -> Result<#entity_name, ::entity_derive::policy::PolicyError<R::Error, P::Error>> {
                 self.policy
                     .can_create(&dto, ctx)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Policy)?;
+                    .map_err(::entity_derive::policy::PolicyError::Policy)?;
                 self.repo
                     .create(dto)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Repository)
+                    .map_err(::entity_derive::policy::PolicyError::Repository)
             }
 
             /// Find entity by ID with authorization check.
@@ -82,16 +82,16 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
                 &self,
                 id: #id_type,
                 ctx: &P::Context,
-            ) -> Result<Option<#entity_name>, ::entity_core::policy::PolicyError<R::Error, P::Error>>
+            ) -> Result<Option<#entity_name>, ::entity_derive::policy::PolicyError<R::Error, P::Error>>
             {
                 self.policy
                     .can_read(&id, ctx)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Policy)?;
+                    .map_err(::entity_derive::policy::PolicyError::Policy)?;
                 self.repo
                     .find_by_id(id)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Repository)
+                    .map_err(::entity_derive::policy::PolicyError::Repository)
             }
 
             /// Update entity with authorization check.
@@ -100,15 +100,15 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
                 id: #id_type,
                 dto: #update_dto,
                 ctx: &P::Context,
-            ) -> Result<#entity_name, ::entity_core::policy::PolicyError<R::Error, P::Error>> {
+            ) -> Result<#entity_name, ::entity_derive::policy::PolicyError<R::Error, P::Error>> {
                 self.policy
                     .can_update(&id, &dto, ctx)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Policy)?;
+                    .map_err(::entity_derive::policy::PolicyError::Policy)?;
                 self.repo
                     .update(id, dto)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Repository)
+                    .map_err(::entity_derive::policy::PolicyError::Repository)
             }
 
             /// Delete entity with authorization check.
@@ -116,15 +116,15 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
                 &self,
                 id: #id_type,
                 ctx: &P::Context,
-            ) -> Result<bool, ::entity_core::policy::PolicyError<R::Error, P::Error>> {
+            ) -> Result<bool, ::entity_derive::policy::PolicyError<R::Error, P::Error>> {
                 self.policy
                     .can_delete(&id, ctx)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Policy)?;
+                    .map_err(::entity_derive::policy::PolicyError::Policy)?;
                 self.repo
                     .delete(id)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Repository)
+                    .map_err(::entity_derive::policy::PolicyError::Repository)
             }
 
             /// List entities with authorization check.
@@ -133,16 +133,16 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
                 limit: i64,
                 offset: i64,
                 ctx: &P::Context,
-            ) -> Result<Vec<#entity_name>, ::entity_core::policy::PolicyError<R::Error, P::Error>>
+            ) -> Result<Vec<#entity_name>, ::entity_derive::policy::PolicyError<R::Error, P::Error>>
             {
                 self.policy
                     .can_list(ctx)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Policy)?;
+                    .map_err(::entity_derive::policy::PolicyError::Policy)?;
                 self.repo
                     .list(limit, offset)
                     .await
-                    .map_err(::entity_core::policy::PolicyError::Repository)
+                    .map_err(::entity_derive::policy::PolicyError::Repository)
             }
         }
     }

--- a/crates/entity-derive-impl/src/entity/repository.rs
+++ b/crates/entity-derive-impl/src/entity/repository.rs
@@ -123,7 +123,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
 
     quote! {
         #marker
-        #[async_trait::async_trait]
+        #[::entity_derive::async_trait]
         #vis trait #trait_name: Send + Sync {
             /// Error type for repository operations.
             type Error: std::error::Error + Send + Sync;
@@ -381,7 +381,7 @@ fn generate_query_method(entity: &EntityDef) -> TokenStream {
 /// async fn stream_filtered(
 ///     &self,
 ///     filter: UserFilter,
-/// ) -> Result<impl futures::Stream<Item = Result<User, sqlx::Error>>, Self::Error>;
+/// ) -> Result<impl ::entity_derive::futures::Stream<Item = Result<User, sqlx::Error>>, Self::Error>;
 /// ```
 pub fn generate_stream_method(entity: &EntityDef) -> TokenStream {
     if !entity.has_streams() || !entity.has_filters() {
@@ -398,7 +398,7 @@ pub fn generate_stream_method(entity: &EntityDef) -> TokenStream {
         async fn stream_filtered(
             &self,
             filter: #filter_type,
-        ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Result<#entity_name, Self::Error>> + Send + '_>>, Self::Error>;
+        ) -> Result<std::pin::Pin<Box<dyn ::entity_derive::futures::Stream<Item = Result<#entity_name, Self::Error>> + Send + '_>>, Self::Error>;
     }
 }
 

--- a/crates/entity-derive-impl/src/entity/schema_check.rs
+++ b/crates/entity-derive-impl/src/entity/schema_check.rs
@@ -8,7 +8,7 @@
 //! drift surfaces as runtime decode errors. The generated constant
 //! describes the declared columns (name, DDL type, nullability) and
 //! `assert_schema(pool)` compares it against
-//! `information_schema.columns` via `entity_core::schema::assert_table`
+//! `information_schema.columns` via `::entity_derive::schema::assert_table`
 //! — one integration test per entity restores a compile-time-like
 //! guarantee:
 //!
@@ -53,7 +53,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             let type_str = sql_type.to_sql_string();
             let nullable = sql_type.nullable;
             quote! {
-                ::entity_core::schema::SchemaColumn {
+                ::entity_derive::schema::SchemaColumn {
                     name: #name,
                     sql_type: #type_str,
                     nullable: #nullable
@@ -69,8 +69,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         #marker
         impl #entity_name {
             #[doc = #schema_doc]
-            pub const SCHEMA: ::entity_core::schema::TableSchema =
-                ::entity_core::schema::TableSchema {
+            pub const SCHEMA: ::entity_derive::schema::TableSchema =
+                ::entity_derive::schema::TableSchema {
                     table: #table,
                     schema: #schema,
                     columns: &[#(#columns),*]
@@ -84,8 +84,8 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             /// entity in an integration test.
             pub async fn assert_schema(
                 pool: &sqlx::PgPool
-            ) -> Result<(), ::entity_core::schema::SchemaCheckError> {
-                ::entity_core::schema::assert_table(pool, &Self::SCHEMA).await
+            ) -> Result<(), ::entity_derive::schema::SchemaCheckError> {
+                ::entity_derive::schema::assert_table(pool, &Self::SCHEMA).await
             }
         }
     }

--- a/crates/entity-derive-impl/src/entity/sql/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres.rs
@@ -134,7 +134,7 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
         #marker
         #constraint_mapper
 
-        #[async_trait::async_trait]
+        #[::entity_derive::async_trait]
         impl #trait_name for sqlx::PgPool {
             type Error = #error_type;
             type Pool = sqlx::PgPool;

--- a/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
@@ -6,7 +6,7 @@
 //! With `#[entity(typed_constraints)]`, generated write methods resolve
 //! the violated constraint name (as reported by Postgres) against the
 //! constraints the macro itself created and surface
-//! `entity_core::ConstraintError` instead of a raw driver error.
+//! `::entity_derive::ConstraintError` instead of a raw driver error.
 //!
 //! # Known Constraint Names
 //!
@@ -18,7 +18,7 @@
 //! | `unique_index(...)` | index name (`idx_{table}_{cols}` or custom) |
 //!
 //! The repository `Error` type must implement
-//! `From<entity_core::ConstraintError>`.
+//! `From<::entity_derive::ConstraintError>`.
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -51,9 +51,9 @@ impl Context<'_> {
         for custom in &self.entity.custom_constraints {
             let name = custom.name.clone();
             let kind = match custom.kind.as_str() {
-                "unique" => quote! { ::entity_core::ConstraintKind::Unique },
-                "foreign_key" => quote! { ::entity_core::ConstraintKind::ForeignKey },
-                _ => quote! { ::entity_core::ConstraintKind::Check }
+                "unique" => quote! { ::entity_derive::ConstraintKind::Unique },
+                "foreign_key" => quote! { ::entity_derive::ConstraintKind::ForeignKey },
+                _ => quote! { ::entity_derive::ConstraintKind::Check }
             };
             let field = match &custom.field {
                 Some(f) => quote! { Some(#f) },
@@ -75,7 +75,7 @@ impl Context<'_> {
                 };
                 if covered.insert(name.clone()) {
                     arms.push(quote! {
-                        #name => Some((::entity_core::ConstraintKind::Unique, Some(#column))),
+                        #name => Some((::entity_derive::ConstraintKind::Unique, Some(#column))),
                     });
                 }
             }
@@ -83,7 +83,7 @@ impl Context<'_> {
                 let name = format!("{table}_{column}_fkey");
                 if covered.insert(name.clone()) {
                     arms.push(quote! {
-                        #name => Some((::entity_core::ConstraintKind::ForeignKey, Some(#column))),
+                        #name => Some((::entity_derive::ConstraintKind::ForeignKey, Some(#column))),
                     });
                 }
             }
@@ -91,7 +91,7 @@ impl Context<'_> {
                 let name = format!("{table}_{column}_check");
                 if covered.insert(name.clone()) {
                     arms.push(quote! {
-                        #name => Some((::entity_core::ConstraintKind::Check, Some(#column))),
+                        #name => Some((::entity_derive::ConstraintKind::Check, Some(#column))),
                     });
                 }
             }
@@ -102,7 +102,7 @@ impl Context<'_> {
                 let name = index.name_or_default(table);
                 if covered.insert(name.clone()) {
                     arms.push(quote! {
-                        #name => Some((::entity_core::ConstraintKind::Unique, None)),
+                        #name => Some((::entity_derive::ConstraintKind::Unique, None)),
                     });
                 }
             }
@@ -117,13 +117,13 @@ impl Context<'_> {
                 if let Some(db_err) = err.as_database_error()
                     && let Some(constraint) = db_err.constraint()
                 {
-                    let resolved: Option<(::entity_core::ConstraintKind, Option<&'static str>)> =
+                    let resolved: Option<(::entity_derive::ConstraintKind, Option<&'static str>)> =
                         match constraint {
                             #(#arms)*
                             _ => None
                         };
                     if let Some((kind, field)) = resolved {
-                        return ::entity_core::ConstraintError {
+                        return ::entity_derive::ConstraintError {
                             kind,
                             constraint: constraint.to_string(),
                             field

--- a/crates/entity-derive-impl/src/entity/sql/postgres/outbox.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/outbox.rs
@@ -6,7 +6,7 @@
 //! When `#[entity(events(outbox))]` is set, every generated write
 //! inserts the serialized `{Entity}Event` into the `entity_outbox`
 //! table **in the same transaction** as the DML. A separate drainer
-//! (`entity_core::outbox::OutboxDrainer`) delivers the rows with
+//! (`::entity_derive::outbox::OutboxDrainer`) delivers the rows with
 //! retry/backoff, so events survive crashes that LISTEN/NOTIFY alone
 //! would lose.
 //!

--- a/crates/entity-derive-impl/src/entity/sql/postgres/query.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/query.rs
@@ -174,8 +174,8 @@ impl Context<'_> {
             async fn stream_filtered(
                 &self,
                 filter: #filter_type,
-            ) -> Result<std::pin::Pin<Box<dyn futures::Stream<Item = Result<#entity_name, Self::Error>> + Send + '_>>, Self::Error> {
-                use futures::StreamExt;
+            ) -> Result<std::pin::Pin<Box<dyn ::entity_derive::futures::Stream<Item = Result<#entity_name, Self::Error>> + Send + '_>>, Self::Error> {
+                use ::entity_derive::futures::StreamExt;
 
                 let mut conditions: Vec<String> = Vec::new();
                 let mut param_idx: usize = 1;
@@ -207,7 +207,7 @@ impl Context<'_> {
                 // Fetch all results and convert to stream for simpler lifetime handling
                 let rows = q.fetch_all(self).await?;
                 let entities: Vec<#entity_name> = rows.into_iter().map(#entity_name::from).collect();
-                let stream = futures::stream::iter(entities.into_iter().map(Ok));
+                let stream = ::entity_derive::futures::stream::iter(entities.into_iter().map(Ok));
 
                 Ok(Box::pin(stream))
             }

--- a/crates/entity-derive-impl/src/entity/streams/subscriber.rs
+++ b/crates/entity-derive-impl/src/entity/streams/subscriber.rs
@@ -54,15 +54,15 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #recv_span
             pub async fn recv(
                 &mut self,
-            ) -> Result<#event_name, ::entity_core::stream::StreamError<::sqlx::Error>> {
+            ) -> Result<#event_name, ::entity_derive::stream::StreamError<::sqlx::Error>> {
                 let notification = self
                     .listener
                     .recv()
                     .await
-                    .map_err(::entity_core::stream::StreamError::Database)?;
+                    .map_err(::entity_derive::stream::StreamError::Database)?;
 
                 ::serde_json::from_str(notification.payload())
-                    .map_err(|e| ::entity_core::stream::StreamError::Deserialize(e.to_string()))
+                    .map_err(|e| ::entity_derive::stream::StreamError::Deserialize(e.to_string()))
             }
 
             /// Try to receive an event without blocking.
@@ -71,17 +71,17 @@ pub fn generate(entity: &EntityDef) -> TokenStream {
             #try_recv_span
             pub async fn try_recv(
                 &mut self,
-            ) -> Result<Option<#event_name>, ::entity_core::stream::StreamError<::sqlx::Error>> {
+            ) -> Result<Option<#event_name>, ::entity_derive::stream::StreamError<::sqlx::Error>> {
                 match self.listener.try_recv().await {
                     Ok(Some(notification)) => {
                         let event = ::serde_json::from_str(notification.payload())
                             .map_err(|e| {
-                                ::entity_core::stream::StreamError::Deserialize(e.to_string())
+                                ::entity_derive::stream::StreamError::Deserialize(e.to_string())
                             })?;
                         Ok(Some(event))
                     }
                     Ok(None) => Ok(None),
-                    Err(e) => Err(::entity_core::stream::StreamError::Database(e)),
+                    Err(e) => Err(::entity_derive::stream::StreamError::Database(e)),
                 }
             }
         }

--- a/crates/entity-derive-impl/src/entity/transaction.rs
+++ b/crates/entity-derive-impl/src/entity/transaction.rs
@@ -328,7 +328,7 @@ fn generate_repo_adapter(entity: &EntityDef) -> TokenStream {
 ///
 /// Each method locks the row with `find_by_id_for_update`, verifies the
 /// current status is one of the declared sources (typed
-/// `entity_core::TransitionError` otherwise), patches `status` plus the
+/// `::entity_derive::TransitionError` otherwise), patches `status` plus the
 /// declared `sets(...)` columns in one UPDATE and returns the persisted
 /// row. `Ok(None)` means the row does not exist.
 fn transition_methods(
@@ -403,7 +403,7 @@ fn transition_methods(
                 "Transition the row to `{target_str}` from {}, patching {}.\n\n\
                  Locks the row for the duration of the transaction; returns\n\
                  `Ok(None)` when the row does not exist and a typed\n\
-                 [`entity_core::TransitionError`] when the current status does\n\
+                 [`::entity_derive::TransitionError`] when the current status does\n\
                  not allow this transition.",
                 t.sources.join("/"),
                 if t.sets.is_empty() {
@@ -427,7 +427,7 @@ fn transition_methods(
                     #[allow(unreachable_patterns)]
                     let allowed = matches!(current.status, #(<#status_type>::#source_variants)|*);
                     if !allowed {
-                        return Err(::entity_core::TransitionError {
+                        return Err(::entity_derive::TransitionError {
                             entity: #entity_name_str,
                             from: format!("{:?}", current.status),
                             to: #target_str
@@ -491,7 +491,7 @@ fn generate_builder_extension(entity: &EntityDef) -> TokenStream {
             fn #method_name(self) -> Self;
         }
 
-        impl<'p> #trait_name<'p> for entity_core::transaction::Transaction<'p, sqlx::PgPool> {
+        impl<'p> #trait_name<'p> for ::entity_derive::transaction::Transaction<'p, sqlx::PgPool> {
             fn #method_name(self) -> Self {
                 self
             }
@@ -521,7 +521,7 @@ fn generate_context_extension(entity: &EntityDef) -> TokenStream {
             fn #accessor_name(&mut self) -> #repo_name<'_>;
         }
 
-        impl #trait_name for entity_core::transaction::TransactionContext {
+        impl #trait_name for ::entity_derive::transaction::TransactionContext {
             fn #accessor_name(&mut self) -> #repo_name<'_> {
                 #repo_name::new(self.transaction())
             }


### PR DESCRIPTION
Closes #246

A project that follows the README — `entity-derive` in `[dependencies]`, nothing else added on the macro's behalf — could not compile a single derived entity:

```
error[E0433]: cannot find `entity_core` in the crate root
```

Generated code addressed its runtime absolutely (`::entity_core::…`, `futures::…`, `async_trait::async_trait`). An absolute path resolves against the *consumer's* extern prelude, so it only worked inside packages that happen to depend on those crates directly — which is every package in this workspace, and no package outside it. Reproduced against 0.22 from crates.io and against `main`.

## Fix

Generated code now goes through the facade only: `::entity_derive::…`. `entity-core` re-exports `futures` under its `streams` feature next to the existing `async_trait` re-export, so both reach consumers through the same path.

## Verification

All ten example crates — the only consumers in this repository shaped like a user project — were broken by this and now build. A new CI job checks every example on each run, which is the regression gate this class of breakage never had.

Checked by hand with a scratch crate carrying nothing but `entity-derive`, `sqlx`, `uuid`, `chrono`, `serde` and `tokio`, deriving an entity with migrations, soft delete, transactions, aggregate root, events, streams, outbox, owner scoping, versioning, projections, filters and sorting: it compiles with no `entity-core`, `futures` or `async-trait` in sight.

## Docs

The installation section now says which crates a consumer still declares — the pool and column types it uses itself — and that the macro's own runtime is not among them.
