### PR TITLE
#240 ci: gate feature combinations, dependency policy and semver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,8 +158,67 @@ jobs:
         with:
           tool: cargo-deny
 
-      - name: Security audit
-        run: cargo deny check advisories
+      # Everything deny.toml configures, not advisories alone: the
+      # licence allow-list, the ban rules and the source allow-list are
+      # policy too, and an unenforced policy drifts.
+      - name: Dependency policy
+        run: cargo deny check
+
+  features:
+    name: Feature Combinations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: features
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-hack
+
+      # The facade carries fifteen features; building only "all on" and
+      # "all off" leaves every combination in between unchecked. Depth 2
+      # covers each feature alone and each pair.
+      - name: Check the feature powerset
+        run: cargo hack check --workspace --feature-powerset --depth 2 --no-dev-deps
+
+  semver:
+    name: Semver
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+        continue-on-error: true
+        with:
+          shared-key: semver
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Install cargo-semver-checks
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-semver-checks
+
+      # Compares the working tree against the versions already on
+      # crates.io, so a breaking change has to be a deliberate version
+      # bump rather than a surprise for downstream users.
+      - name: Check API compatibility
+        run: cargo semver-checks check-release --workspace --exclude entity-derive-impl
 
   reuse:
     name: REUSE Compliance

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,10 @@ run drops it once it is half an hour old.
 | Lint | `cargo clippy -- -D warnings` |
 | Test | `cargo test` |
 | Live Postgres | `cargo nextest run -p entity-derive --all-features --test postgres` (matrix: Postgres 18, 17) |
+| Examples | `cargo check --manifest-path examples/<name>/Cargo.toml --all-targets` |
+| Feature combinations | `cargo hack check --workspace --feature-powerset --depth 2 --no-dev-deps` |
+| Dependency policy | `cargo deny check` |
+| Semver | `cargo semver-checks check-release --workspace --exclude entity-derive-impl` |
 | Coverage | `cargo llvm-cov` (95%+ required) |
 
 ## Code standards

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -7,14 +7,23 @@
     html_favicon_url = "https://raw.githubusercontent.com/RAprogramm/entity-derive/main/assets/favicon.ico"
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-// Several parsing helpers (column DDL, composite indexes, projection
-// metadata) are only consumed by the `migrations` and `projections`
-// generators. When users opt out of those features, the helpers become
-// unused — silence the dead-code lint in those configurations so minimal
-// builds stay warning-clean. Default builds (every feature on) keep the
-// warning active.
+// The macro parses every attribute regardless of which generators are
+// compiled in, so the parse layer carries helpers — column DDL,
+// composite indexes, projection metadata, command sources, transition
+// definitions — that only one generator consumes. Switching that
+// generator off leaves its helpers legitimately unused, and a minimal
+// build must still be warning-clean. With every generator on (the
+// default, and what CI builds) the lints stay active.
 #![cfg_attr(
-    any(not(feature = "migrations"), not(feature = "projections")),
+    not(all(
+        feature = "events",
+        feature = "commands",
+        feature = "hooks",
+        feature = "transactions",
+        feature = "aggregate_root",
+        feature = "migrations",
+        feature = "projections"
+    )),
     allow(dead_code, unused_imports)
 )]
 #![warn(


### PR DESCRIPTION
Closes #240

Three gates the repository was configured for but did not enforce. The examples gate from the same issue landed with #246, where broken examples were the evidence.

| Job | Command | Why |
|---|---|---|
| Feature Combinations | `cargo hack check --workspace --feature-powerset --depth 2 --no-dev-deps` | fifteen features were only ever built all-on and all-off; depth 2 covers each feature alone and each pair. 197s locally, runs in parallel with the other checks |
| Security Audit | `cargo deny check` instead of `cargo deny check advisories` | the licence allow-list, ban rules and source allow-list in `deny.toml` were configured and never enforced |
| Semver | `cargo semver-checks check-release --workspace --exclude entity-derive-impl` | a frequently released public API with no breaking-change detection. The proc-macro crate is excluded: it exports macros only |

All three pass on the current tree. `CONTRIBUTING.md` lists them so the local run matches CI.