### PR TITLE
#243 fix: reject SQL identifiers that generated statements cannot carry

### DIFF
--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -65,7 +65,7 @@ use super::{
     parse_projection_attrs,
     upsert::{UpsertAction, UpsertDef}
 };
-use crate::utils::docs::extract_doc_comments;
+use crate::utils::{docs::extract_doc_comments, sql_ident};
 
 impl EntityDef {
     /// Parse entity definition from syn's `DeriveInput`.
@@ -126,6 +126,8 @@ impl EntityDef {
                 );
             }
         };
+
+        validate_sql_names(&attrs.table, &attrs.schema, &fields, input)?;
 
         let has_many = parse_has_many_attrs(&input.attrs);
         let projections = parse_projection_attrs(&input.attrs);
@@ -424,6 +426,35 @@ fn expand_embed_fields(fields: &mut Vec<FieldDef>) -> darling::Result<()> {
 /// | Conflict target carries a uniqueness guarantee | `ON CONFLICT` requires a unique index or constraint |
 /// | `returning = "full"` | The returned entity must reflect the persisted row, which on the update path is the pre-existing one |
 /// | `action = "update"` needs a non-conflict insert column | An empty `DO UPDATE SET` is invalid SQL |
+/// Reject table, schema and column names that generated SQL cannot
+/// carry unquoted.
+///
+/// The generator interpolates these names into statements as written,
+/// so a reserved word or an upper-case letter produces SQL that fails
+/// at runtime — and only once that statement runs. Checking here turns
+/// it into an error at the offending attribute.
+fn validate_sql_names(
+    table: &str,
+    schema: &str,
+    fields: &[FieldDef],
+    input: &DeriveInput
+) -> darling::Result<()> {
+    sql_ident::validate("table", table)
+        .map_err(|msg| darling::Error::custom(msg).with_span(&input.ident))?;
+
+    if !schema.is_empty() {
+        sql_ident::validate("schema", schema)
+            .map_err(|msg| darling::Error::custom(msg).with_span(&input.ident))?;
+    }
+
+    for field in fields {
+        sql_ident::validate("column", &field.column_name())
+            .map_err(|msg| darling::Error::custom(msg).with_span(&field.ident))?;
+    }
+
+    Ok(())
+}
+
 fn validate_upsert(
     upsert: &UpsertDef,
     fields: &[FieldDef],

--- a/crates/entity-derive-impl/src/utils.rs
+++ b/crates/entity-derive-impl/src/utils.rs
@@ -10,9 +10,11 @@
 //! - [`docs`] — Documentation extraction from attributes
 //! - [`fields`] — Field assignment generation for `From` implementations
 //! - [`marker`] — Generated code marker comments
+//! - [`sql_ident`] — Validation of identifiers that reach generated SQL
 //! - [`tracing`] — Optional `#[tracing::instrument]` attribute emission
 
 pub mod docs;
 pub mod fields;
 pub mod marker;
+pub mod sql_ident;
 pub mod tracing;

--- a/crates/entity-derive-impl/src/utils/sql_ident.rs
+++ b/crates/entity-derive-impl/src/utils/sql_ident.rs
@@ -1,0 +1,212 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Compile-time validation of the identifiers that reach generated SQL.
+//!
+//! Table, schema and column names are interpolated into the generated
+//! statements unquoted. A name that needs quoting — a reserved word, an
+//! upper-case letter, a space — produces SQL that parses only at
+//! runtime, and only once that particular statement is executed. This
+//! module turns that into a compile error at the attribute that caused
+//! it.
+//!
+//! ```rust,ignore
+//! #[entity(table = "user")]   // rejected: `user` is reserved in SQL
+//! #[entity(table = "Users")]  // rejected: unquoted SQL folds it to `users`
+//! ```
+
+/// SQL keywords that cannot appear unquoted where this macro puts
+/// identifiers.
+///
+/// Postgres tolerates some of these as column names but not as table
+/// names, and the set differs between dialects; the list is the
+/// intersection that is unsafe everywhere the generator interpolates a
+/// name.
+const RESERVED: &[&str] = &[
+    "all",
+    "analyse",
+    "analyze",
+    "and",
+    "any",
+    "array",
+    "as",
+    "asc",
+    "authorization",
+    "between",
+    "binary",
+    "both",
+    "case",
+    "cast",
+    "check",
+    "collate",
+    "column",
+    "constraint",
+    "create",
+    "cross",
+    "current_date",
+    "current_role",
+    "current_time",
+    "current_timestamp",
+    "current_user",
+    "default",
+    "deferrable",
+    "desc",
+    "distinct",
+    "do",
+    "else",
+    "end",
+    "except",
+    "false",
+    "for",
+    "foreign",
+    "freeze",
+    "from",
+    "full",
+    "grant",
+    "group",
+    "having",
+    "ilike",
+    "in",
+    "initially",
+    "inner",
+    "intersect",
+    "into",
+    "is",
+    "isnull",
+    "join",
+    "leading",
+    "left",
+    "like",
+    "limit",
+    "localtime",
+    "localtimestamp",
+    "natural",
+    "not",
+    "notnull",
+    "null",
+    "offset",
+    "on",
+    "only",
+    "or",
+    "order",
+    "outer",
+    "overlaps",
+    "placing",
+    "primary",
+    "references",
+    "returning",
+    "right",
+    "select",
+    "session_user",
+    "similar",
+    "some",
+    "symmetric",
+    "table",
+    "then",
+    "to",
+    "trailing",
+    "true",
+    "union",
+    "unique",
+    "user",
+    "using",
+    "variadic",
+    "verbose",
+    "when",
+    "where",
+    "window",
+    "with"
+];
+
+/// Longest identifier Postgres keeps without truncating it.
+const MAX_LEN: usize = 63;
+
+/// Check one identifier destined for generated SQL.
+///
+/// `kind` names the attribute in the error message (`table`, `schema`,
+/// `column`), so the report points at what to change.
+///
+/// # Errors
+///
+/// Returns the message to hand to `compile_error!` when the name would
+/// need quoting to survive in generated SQL.
+pub fn validate(kind: &str, name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err(format!("{kind} name must not be empty"));
+    }
+
+    if name.len() > MAX_LEN {
+        return Err(format!(
+            "{kind} name `{name}` is {} bytes; Postgres truncates identifiers at {MAX_LEN}, \
+             which would silently rename it",
+            name.len()
+        ));
+    }
+
+    if let Some(bad) = name
+        .chars()
+        .find(|c| !(c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '_'))
+    {
+        return Err(format!(
+            "{kind} name `{name}` contains `{bad}`; generated SQL interpolates it unquoted, so \
+             it must be lower-case ASCII, digits or underscore"
+        ));
+    }
+
+    if name.starts_with(|c: char| c.is_ascii_digit()) {
+        return Err(format!(
+            "{kind} name `{name}` starts with a digit; SQL identifiers must start with a letter \
+             or underscore"
+        ));
+    }
+
+    if RESERVED.contains(&name) {
+        return Err(format!(
+            "{kind} name `{name}` is a reserved SQL word and would need quoting; rename it (for \
+             example `{name}s`)"
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate;
+
+    #[test]
+    fn plain_names_pass() {
+        assert!(validate("table", "users").is_ok());
+        assert!(validate("column", "created_at").is_ok());
+        assert!(validate("column", "addr_line_2").is_ok());
+        assert!(validate("schema", "_internal").is_ok());
+    }
+
+    #[test]
+    fn reserved_words_are_rejected() {
+        let err = validate("table", "user").unwrap_err();
+        assert!(err.contains("reserved"), "{err}");
+        assert!(
+            err.contains("`users`"),
+            "the hint should suggest a fix: {err}"
+        );
+        assert!(validate("table", "order").is_err());
+        assert!(validate("column", "default").is_err());
+    }
+
+    #[test]
+    fn case_and_punctuation_are_rejected() {
+        assert!(validate("table", "Users").is_err());
+        assert!(validate("table", "user profiles").is_err());
+        assert!(validate("table", "users; DROP TABLE x").is_err());
+        assert!(validate("column", "créé_à").is_err());
+    }
+
+    #[test]
+    fn shape_rules_are_enforced() {
+        assert!(validate("table", "").is_err());
+        assert!(validate("table", "2fa_tokens").is_err());
+        assert!(validate("table", &"a".repeat(64)).is_err());
+        assert!(validate("table", &"a".repeat(63)).is_ok());
+    }
+}

--- a/crates/entity-derive/tests/cases/fail/quoted_column_name.rs
+++ b/crates/entity-derive/tests/cases/fail/quoted_column_name.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! An explicit column name that needs quoting is rejected at the
+//! attribute instead of failing when the statement runs.
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Entity)]
+#[entity(table = "accounts")]
+pub struct Account {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    #[column(name = "Full Name")]
+    pub name: String,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/quoted_column_name.stderr
+++ b/crates/entity-derive/tests/cases/fail/quoted_column_name.stderr
@@ -1,0 +1,5 @@
+error: column name `Full Name` contains `F`; generated SQL interpolates it unquoted, so it must be lower-case ASCII, digits or underscore
+  --> tests/cases/fail/quoted_column_name.rs:18:9
+   |
+18 |     pub name: String,
+   |         ^^^^

--- a/crates/entity-derive/tests/cases/fail/reserved_table_name.rs
+++ b/crates/entity-derive/tests/cases/fail/reserved_table_name.rs
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! A reserved SQL word as a table name would produce SQL that only
+//! fails at runtime.
+
+use entity_derive::Entity;
+use uuid::Uuid;
+
+#[derive(Entity)]
+#[entity(table = "user")]
+pub struct Account {
+    #[id]
+    pub id: Uuid,
+
+    #[field(create, update, response)]
+    pub name: String,
+}
+
+fn main() {}

--- a/crates/entity-derive/tests/cases/fail/reserved_table_name.stderr
+++ b/crates/entity-derive/tests/cases/fail/reserved_table_name.stderr
@@ -1,0 +1,5 @@
+error: table name `user` is a reserved SQL word and would need quoting; rename it (for example `users`)
+  --> tests/cases/fail/reserved_table_name.rs:12:12
+   |
+12 | pub struct Account {
+   |            ^^^^^^^


### PR DESCRIPTION
Closes #243

Table, schema and column names are interpolated into generated SQL unquoted. A name that needs quoting — a reserved word like `user` or `order`, an upper-case letter, a space — produced SQL that failed only at runtime, and only once that particular statement ran.

They are now checked while the attribute is parsed:

| Rejected | Reason |
|---|---|
| reserved SQL words | would need quoting where the generator cannot add it |
| upper case, punctuation, non-ASCII | unquoted SQL folds or rejects them |
| leading digit | not a valid SQL identifier |
| longer than 63 bytes | Postgres truncates, silently renaming the object |
| empty | nothing to interpolate |

The message names the attribute and suggests the fix:

```
error: table name `user` is a reserved SQL word and would need quoting; rename it (for example `users`)
```

Two trybuild cases cover the rejections, unit tests cover the rule set. Every existing case, example and the live-Postgres suite are unaffected.

Note for the changelog: an entity that today names a table or column with a reserved word stops compiling. It was already producing invalid SQL at runtime, so the error surfaces an existing defect rather than removing working behaviour.