### PR TITLE
#241 chore: one lint policy for the workspace with pedantic on

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,42 @@ trybuild = "1"
 utoipa = { version = "5", features = ["chrono", "uuid"] }
 validator = { version = "0.20", features = ["derive"] }
 
+# One lint policy for every crate. Pedantic is on: what stays allowed
+# is listed here with the reason, instead of a per-crate pile of
+# `#![allow(...)]` that silently covers future occurrences too.
+[workspace.lints.rust]
+rust_2018_idioms = { level = "warn", priority = -1 }
+unsafe_code = "deny"
+
+[workspace.lints.clippy]
+pedantic = { level = "warn", priority = -1 }
+# Parse structs arrive from darling by value and are moved into the
+# entity definition; taking them by reference would force a clone.
+needless_pass_by_value = "allow"
+# Dialect and attribute matches stay exhaustive and one arm per case, so
+# adding a variant is a compile error rather than a silent fallthrough.
+match_same_arms = "allow"
+# A generator function is one SQL template read top to bottom; splitting
+# it into fragments hides the statement it produces.
+too_many_lines = "allow"
+# Attribute configuration structs mirror the attribute surface, which is
+# a set of independent flags.
+struct_excessive_bools = "allow"
+# `Option<Option<T>>` is the PATCH contract: absent field versus
+# explicit null.
+option_option = "allow"
+# Field and column descriptors are passed by reference throughout;
+# switching the small ones to by-value would split the convention.
+trivially_copy_pass_by_ref = "allow"
+# Prose in the docs names SQL keywords and types without backticks.
+doc_markdown = "allow"
+# SQL is assembled fragment by fragment; `push_str(&format!(..))` keeps
+# the statement readable, unlike `write!` with an ignored Result.
+format_push_string = "allow"
+# Raised inside the parser darling generates for the attribute structs,
+# where there is no source line to change.
+needless_continue = "allow"
+
 [workspace.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/entity-core/Cargo.toml
+++ b/crates/entity-core/Cargo.toml
@@ -38,6 +38,9 @@ tracing = { version = "0.1", optional = true }
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt"] }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/entity-core/src/lib.rs
+++ b/crates/entity-core/src/lib.rs
@@ -29,7 +29,6 @@
 //! ```
 
 #![warn(missing_docs)]
-#![warn(clippy::all)]
 
 #[cfg(feature = "outbox")]
 pub mod outbox;

--- a/crates/entity-core/src/outbox.rs
+++ b/crates/entity-core/src/outbox.rs
@@ -266,11 +266,11 @@ pub async fn process_rows<H: OutboxHandler>(
 #[must_use]
 pub fn backoff_delay(base: Duration, attempts: i32, max_attempts: i32) -> Duration {
     if attempts + 1 >= max_attempts {
-        return Duration::from_secs(60 * 60 * 24 * 30);
+        return Duration::from_hours(720);
     }
     let exp = u32::try_from(attempts.clamp(0, 20)).unwrap_or(0);
     let delay = base.saturating_mul(2u32.saturating_pow(exp));
-    delay.min(Duration::from_secs(3600))
+    delay.min(Duration::from_hours(1))
 }
 
 #[cfg(test)]
@@ -329,7 +329,7 @@ mod tests {
             actions,
             vec![OutboxAction::ScheduleRetry {
                 id:    3,
-                delay: Duration::from_secs(60 * 60 * 24 * 30)
+                delay: Duration::from_hours(720)
             }]
         );
     }
@@ -360,14 +360,14 @@ mod tests {
     #[test]
     fn backoff_caps_at_one_hour() {
         let base = Duration::from_secs(5);
-        assert_eq!(backoff_delay(base, 15, 20), Duration::from_secs(3600));
+        assert_eq!(backoff_delay(base, 15, 20), Duration::from_hours(1));
     }
 
     #[test]
     fn backoff_parks_after_max_attempts() {
         let base = Duration::from_secs(5);
         let parked = backoff_delay(base, 9, 10);
-        assert_eq!(parked, Duration::from_secs(60 * 60 * 24 * 30));
+        assert_eq!(parked, Duration::from_hours(720));
     }
 
     #[test]

--- a/crates/entity-core/src/transaction.rs
+++ b/crates/entity-core/src/transaction.rs
@@ -312,7 +312,7 @@ impl Transaction<'_, sqlx::PgPool> {
         let tx = self.pool.begin().await.map_err(E::from)?;
         let mut ctx = TransactionContext::new(tx);
         let result = f(&mut ctx).await;
-        finalize_with_commit(ctx, result, |c| c.commit()).await
+        finalize_with_commit(ctx, result, TransactionContext::commit).await
     }
 
     /// Execute a closure within a transaction with explicit commit.

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -91,6 +91,9 @@ utoipa = { version = "5", features = ["chrono", "uuid"] }
 validator = { version = "0.20", features = ["derive"] }
 entity-core = { path = "../entity-core" }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/entity-derive-impl/src/entity/migrations/postgres.rs
+++ b/crates/entity-derive-impl/src/entity/migrations/postgres.rs
@@ -187,7 +187,7 @@ fn junction_migration_const(entity: &EntityDef) -> TokenStream {
     let id_sql = crate::entity::migrations::types::TypeMapper::map_type(
         &mapper,
         id_field.ty(),
-        &Default::default()
+        &crate::entity::parse::ColumnConfig::default()
     )
     .name;
     let parent_snake = entity.name_str().to_case(convert_case::Case::Snake);

--- a/crates/entity-derive-impl/src/entity/parse/dialect.rs
+++ b/crates/entity-derive-impl/src/entity/parse/dialect.rs
@@ -64,7 +64,11 @@ impl DatabaseDialect {
     }
 
     /// Generate comma-separated placeholders for given count.
+    ///
+    /// Every dialect numbers placeholders the same way, so the receiver
+    /// is kept for call-site symmetry with the rest of the dialect API.
     #[must_use]
+    #[allow(clippy::unused_self)]
     pub fn placeholders(&self, count: usize) -> String {
         (1..=count)
             .map(|i| format!("${i}"))

--- a/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
+++ b/crates/entity-derive-impl/src/entity/parse/entity/constructor.rs
@@ -59,7 +59,12 @@ use darling::FromDeriveInput;
 use syn::DeriveInput;
 
 use super::{
-    super::{command::parse_command_attrs, field::FieldDef, returning::ReturningMode},
+    super::{
+        ColumnConfig, MapConfig,
+        command::parse_command_attrs,
+        field::{ExposeConfig, FieldDef, FilterConfig, StorageConfig, ValidationConfig},
+        returning::ReturningMode
+    },
     CompositeIndexDef, EntityAttrs, EntityDef,
     helpers::{parse_api_attr, parse_constraint_attrs, parse_has_many_attrs, parse_index_attrs},
     parse_projection_attrs,
@@ -393,14 +398,14 @@ fn expand_embed_fields(fields: &mut Vec<FieldDef>) -> darling::Result<()> {
                 sortable:     false,
                 embed:        None,
                 embed_origin: Some((field.ident.clone(), sub.clone())),
-                expose:       Default::default(),
-                storage:      Default::default(),
-                filter:       Default::default(),
-                column:       Default::default(),
+                expose:       ExposeConfig::default(),
+                storage:      StorageConfig::default(),
+                filter:       FilterConfig::default(),
+                column:       ColumnConfig::default(),
                 doc:          None,
-                validation:   Default::default(),
+                validation:   ValidationConfig::default(),
                 example:      None,
-                map:          Default::default()
+                map:          MapConfig::default()
             });
         }
         insertions.push((idx + 1, synthetic));

--- a/crates/entity-derive-impl/src/entity/parse/field/example.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/example.rs
@@ -162,12 +162,12 @@ mod tests {
     #[test]
     fn parse_int_example() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[example = 42]
                 age: i32,
             }
-        "#
+        "
         );
         let example = parse_example_attr(&attrs);
         assert!(matches!(example, Some(ExampleValue::Int(42))));
@@ -176,12 +176,12 @@ mod tests {
     #[test]
     fn parse_negative_int_example() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[example = -10]
                 temperature: i32,
             }
-        "#
+        "
         );
         let example = parse_example_attr(&attrs);
         assert!(matches!(example, Some(ExampleValue::Int(-10))));
@@ -190,12 +190,12 @@ mod tests {
     #[test]
     fn parse_float_example() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[example = 99.99]
                 price: f64,
             }
-        "#
+        "
         );
         let example = parse_example_attr(&attrs);
         assert!(matches!(example, Some(ExampleValue::Float(f)) if (f - 99.99).abs() < 0.001));
@@ -204,12 +204,12 @@ mod tests {
     #[test]
     fn parse_bool_example() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[example = true]
                 active: bool,
             }
-        "#
+        "
         );
         let example = parse_example_attr(&attrs);
         assert!(matches!(example, Some(ExampleValue::Bool(true))));
@@ -218,12 +218,12 @@ mod tests {
     #[test]
     fn no_example_attr() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[field(create)]
                 name: String,
             }
-        "#
+        "
         );
         let example = parse_example_attr(&attrs);
         assert!(example.is_none());
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn to_schema_attr_float() {
-        let example = ExampleValue::Float(3.14);
+        let example = ExampleValue::Float(1.5);
         let tokens = example.to_schema_attr().to_string();
         assert!(tokens.contains("example"));
     }
@@ -291,12 +291,12 @@ mod tests {
     #[test]
     fn parse_example_expr_float() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[example = -0.5]
                 temp: f64,
             }
-        "#
+        "
         );
         let example = parse_example_attr(&attrs);
         assert!(matches!(example, Some(ExampleValue::Float(f)) if (f - (-0.5)).abs() < 0.001));

--- a/crates/entity-derive-impl/src/entity/parse/field/validation.rs
+++ b/crates/entity-derive-impl/src/entity/parse/field/validation.rs
@@ -213,12 +213,12 @@ mod tests {
     #[test]
     fn parse_length_min_max() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(length(min = 1, max = 255))]
                 name: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert_eq!(config.min_length, Some(1));
@@ -228,12 +228,12 @@ mod tests {
     #[test]
     fn parse_email() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(email)]
                 email: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert!(config.email);
@@ -242,12 +242,12 @@ mod tests {
     #[test]
     fn parse_url() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(url)]
                 website: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert!(config.url);
@@ -256,12 +256,12 @@ mod tests {
     #[test]
     fn parse_range() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(range(min = 0, max = 100))]
                 score: i32,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert_eq!(config.minimum, Some(0));
@@ -271,13 +271,13 @@ mod tests {
     #[test]
     fn parse_multiple_validators() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(length(min = 5))]
                 #[validate(email)]
                 email: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert_eq!(config.min_length, Some(5));
@@ -287,12 +287,12 @@ mod tests {
     #[test]
     fn no_validation() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[field(create)]
                 name: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert!(!config.has_validation());
@@ -301,12 +301,12 @@ mod tests {
     #[test]
     fn has_validation_true() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(email)]
                 email: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert!(config.has_validation());
@@ -455,12 +455,12 @@ mod tests {
     #[test]
     fn raw_attrs_stored() {
         let attrs = parse_attrs(
-            r#"
+            r"
             struct Foo {
                 #[validate(length(min = 1))]
                 name: String,
             }
-        "#
+        "
         );
         let config = parse_validation_attrs(&attrs);
         assert!(!config.raw_attrs.is_empty());

--- a/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/constraints.rs
@@ -55,9 +55,10 @@ impl Context<'_> {
                 "foreign_key" => quote! { ::entity_derive::ConstraintKind::ForeignKey },
                 _ => quote! { ::entity_derive::ConstraintKind::Check }
             };
-            let field = match &custom.field {
-                Some(f) => quote! { Some(#f) },
-                None => quote! { None }
+            let field = if let Some(f) = &custom.field {
+                quote! { Some(#f) }
+            } else {
+                quote! { None }
             };
             covered.insert(name.clone());
             arms.push(quote! {

--- a/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
+++ b/crates/entity-derive-impl/src/entity/sql/postgres/helpers.rs
@@ -387,22 +387,20 @@ mod tests {
         assert_eq!(bindings.len(), 2);
 
         let first = bindings[0].to_string();
-        assert!(first.contains("bind"), "Expected 'bind' in: {}", first);
+        assert!(first.contains("bind"), "Expected 'bind' in: {first}");
         assert!(
             first.contains("insertable"),
-            "Expected 'insertable' in: {}",
-            first
+            "Expected 'insertable' in: {first}"
         );
-        assert!(first.contains("id"), "Expected 'id' in: {}", first);
+        assert!(first.contains("id"), "Expected 'id' in: {first}");
 
         let second = bindings[1].to_string();
-        assert!(second.contains("bind"), "Expected 'bind' in: {}", second);
+        assert!(second.contains("bind"), "Expected 'bind' in: {second}");
         assert!(
             second.contains("insertable"),
-            "Expected 'insertable' in: {}",
-            second
+            "Expected 'insertable' in: {second}"
         );
-        assert!(second.contains("name"), "Expected 'name' in: {}", second);
+        assert!(second.contains("name"), "Expected 'name' in: {second}");
     }
 
     #[test]

--- a/crates/entity-derive-impl/src/error.rs
+++ b/crates/entity-derive-impl/src/error.rs
@@ -320,7 +320,7 @@ mod tests {
             if let syn::Data::Enum(data) = &input.data {
                 let variant = &data.variants[0];
                 let result = parse_status_attr(&variant.attrs);
-                assert!(result.is_ok(), "Should parse status code {}", code_str);
+                assert!(result.is_ok(), "Should parse status code {code_str}");
             }
         }
     }

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -29,27 +29,8 @@
 #![warn(
     missing_docs,
     rustdoc::missing_crate_level_docs,
-    rustdoc::broken_intra_doc_links,
-    rust_2018_idioms
+    rustdoc::broken_intra_doc_links
 )]
-#![deny(unsafe_code)]
-#![allow(clippy::option_if_let_else)]
-#![allow(clippy::match_same_arms)]
-#![allow(clippy::trivially_copy_pass_by_ref)]
-#![allow(clippy::struct_excessive_bools)]
-#![allow(clippy::too_many_lines)]
-#![allow(clippy::format_push_string)]
-#![allow(clippy::unused_self)]
-#![allow(clippy::needless_continue)]
-#![allow(clippy::needless_pass_by_value)]
-#![allow(clippy::uninlined_format_args)]
-#![allow(clippy::needless_raw_string_hashes)]
-#![allow(clippy::doc_markdown)]
-#![allow(clippy::missing_const_for_fn)]
-#![allow(clippy::used_underscore_binding)]
-#![allow(clippy::useless_format)]
-#![allow(clippy::approx_constant)]
-#![allow(clippy::needless_collect)]
 
 //! # Quick Navigation
 //!

--- a/crates/entity-derive-impl/src/utils/docs.rs
+++ b/crates/entity-derive-impl/src/utils/docs.rs
@@ -116,10 +116,10 @@ mod tests {
     #[test]
     fn extract_single_line_doc() {
         let attrs = parse_attrs(
-            r#"
+            r"
             /// User entity.
             struct Foo;
-        "#
+        "
         );
         let docs = extract_doc_comments(&attrs);
         assert_eq!(docs, Some("User entity.".to_string()));
@@ -128,11 +128,11 @@ mod tests {
     #[test]
     fn extract_multi_line_doc() {
         let attrs = parse_attrs(
-            r#"
+            r"
             /// First line.
             /// Second line.
             struct Foo;
-        "#
+        "
         );
         let docs = extract_doc_comments(&attrs);
         assert_eq!(docs, Some("First line.\nSecond line.".to_string()));
@@ -141,12 +141,12 @@ mod tests {
     #[test]
     fn extract_doc_with_empty_lines() {
         let attrs = parse_attrs(
-            r#"
+            r"
             /// Summary.
             ///
             /// Details here.
             struct Foo;
-        "#
+        "
         );
         let docs = extract_doc_comments(&attrs);
         assert_eq!(docs, Some("Summary.\n\nDetails here.".to_string()));
@@ -155,10 +155,10 @@ mod tests {
     #[test]
     fn extract_no_docs() {
         let attrs = parse_attrs(
-            r#"
+            r"
             #[derive(Debug)]
             struct Foo;
-        "#
+        "
         );
         let docs = extract_doc_comments(&attrs);
         assert_eq!(docs, None);
@@ -167,11 +167,11 @@ mod tests {
     #[test]
     fn extract_summary_only() {
         let attrs = parse_attrs(
-            r#"
+            r"
             /// First line summary.
             /// More details.
             struct Foo;
-        "#
+        "
         );
         let summary = extract_doc_summary(&attrs);
         assert_eq!(summary, Some("First line summary.".to_string()));
@@ -180,11 +180,11 @@ mod tests {
     #[test]
     fn extract_summary_skips_empty_first_line() {
         let attrs = parse_attrs(
-            r#"
+            r"
             ///
             /// Actual summary.
             struct Foo;
-        "#
+        "
         );
         let summary = extract_doc_summary(&attrs);
         assert_eq!(summary, Some("Actual summary.".to_string()));

--- a/crates/entity-derive-impl/src/value_object.rs
+++ b/crates/entity-derive-impl/src/value_object.rs
@@ -476,15 +476,15 @@ mod tests {
     #[test]
     fn generate_for_non_enum_fails() {
         let input = parse_input(
-            r#"
+            r"
             struct NotAnEnum {
                 field: String,
             }
-            "#
+            "
         );
 
-        let _result = generate(&input);
-        assert!(_result.is_err());
+        let result = generate(&input);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -101,6 +101,9 @@ axum = "0.8"
 garde = { version = "0.23", features = ["derive", "email", "url"] }
 masterror = { version = "0.29", features = ["axum", "openapi"] }
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
Closes #241

`entity-derive-impl` carried seventeen crate-wide `#![allow(clippy::…)]` lines. Most suppressed pedantic lints that were never enabled, so they hid nothing today and would hide everything the day pedantic was turned on. The three crates also disagreed on which lints they warned about at all.

## Now

`[workspace.lints]` is the single policy, inherited by all three crates: `clippy::pedantic` at warn, `unsafe_code` denied, `rust_2018_idioms` at warn. What stays allowed is listed there with the reason it stays — parse structs moved by value, exhaustive one-arm-per-case matches, generator functions that read as one SQL template, the double-`Option` PATCH contract, and two lints raised inside darling-generated code.

## Fixed rather than allowed

Format arguments inlined, redundant raw-string hashes dropped, `Default::default()` replaced by the named type, `Duration` constructed in the unit it means, a redundant closure, an underscore-prefixed binding, an approximate PI in test data, and a receiver kept for API symmetry now says so at the item instead of crate-wide.

Clippy is clean at `-D warnings` across all targets and all features, the 258 feature combinations still pass with warnings denied, and all 808 tests pass.