### PR TITLE
#244 docs: mark the ClickHouse and MongoDB dialects as unimplemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ serde = { version = "1", features = ["derive"] }
 | `aggregate_root` | ✓ | `New{Entity}` constructor type and transactional `save()` (`#[entity(aggregate_root)]`) |
 | `migrations` | ✓ | Compile-time `MIGRATION_UP` / `MIGRATION_DOWN` SQL constants (`#[entity(migrations)]`) |
 | `projections` | ✓ | Projection structs and `find_by_id_<projection>` lookups (`#[projection(...)]`) |
-| `clickhouse` |   | Generate ClickHouse-backed repositories *(planned)* |
-| `mongodb` |   | Generate MongoDB-backed repositories *(planned)* |
+| `clickhouse` |   | **Not implemented** — selecting this dialect is a compile error ([#23](https://github.com/RAprogramm/entity-derive/issues/23)) |
+| `mongodb` |   | **Not implemented** — selecting this dialect is a compile error ([#24](https://github.com/RAprogramm/entity-derive/issues/24)) |
 | `streams` |   | `{Entity}Subscriber` using Postgres `LISTEN`/`NOTIFY` (pulls in `events`) |
 | `outbox` |   | Transactional-outbox enqueue in generated writes + `OutboxDrainer` runtime (pulls in `events`) |
 | `api` |   | Generate HTTP handlers (`axum`) and `utoipa` OpenAPI schemas |

--- a/crates/entity-derive-impl/src/entity/sql/clickhouse.rs
+++ b/crates/entity-derive-impl/src/entity/sql/clickhouse.rs
@@ -25,9 +25,10 @@ use crate::entity::parse::EntityDef;
 pub fn generate(_entity: &EntityDef) -> TokenStream {
     quote! {
         compile_error!(
-            "ClickHouse support is not yet implemented. \
+            "ClickHouse support is not implemented; see \
+             https://github.com/RAprogramm/entity-derive/issues/23. \
              Use `sql = \"trait\"` to generate only the trait, \
-             then implement it manually for `clickhouse::Client`."
+             then implement it for `clickhouse::Client`."
         );
     }
 }

--- a/crates/entity-derive-impl/src/entity/sql/mongodb.rs
+++ b/crates/entity-derive-impl/src/entity/sql/mongodb.rs
@@ -25,9 +25,10 @@ use crate::entity::parse::EntityDef;
 pub fn generate(_entity: &EntityDef) -> TokenStream {
     quote! {
         compile_error!(
-            "MongoDB support is not yet implemented. \
+            "MongoDB support is not implemented; see \
+             https://github.com/RAprogramm/entity-derive/issues/24. \
              Use `sql = \"trait\"` to generate only the trait, \
-             then implement it manually for `mongodb::Client`."
+             then implement it for `mongodb::Client`."
         );
     }
 }

--- a/crates/entity-derive-impl/src/lib.rs
+++ b/crates/entity-derive-impl/src/lib.rs
@@ -49,7 +49,7 @@
 //!     table = "users",      // Required: database table name
 //!     schema = "public",    // Optional: database schema (omit to exclude from SQL)
 //!     sql = "full",         // Optional: "full" | "trait" | "none" (default: "full")
-//!     dialect = "postgres", // Optional: "postgres" | "clickhouse" | "mongodb" (default: "postgres")
+//!     dialect = "postgres", // Optional; "postgres" is the only implemented dialect
 //!     uuid = "v7"           // Optional: "v7" | "v4" (default: "v7")
 //! )]
 //! pub struct User { /* ... */ }
@@ -272,7 +272,7 @@ use proc_macro::TokenStream;
 /// | `table` | **Yes** | — | Database table name |
 /// | `schema` | No | — | Database schema name (omitted = no prefix in SQL) |
 /// | `sql` | No | `"full"` | SQL generation: `"full"`, `"trait"`, or `"none"` |
-/// | `dialect` | No | `"postgres"` | Database dialect: `"postgres"`, `"clickhouse"`, `"mongodb"` |
+/// | `dialect` | No | `"postgres"` | Database dialect. `"postgres"` is the only implemented one; `"clickhouse"` and `"mongodb"` parse but fail to compile |
 /// | `uuid` | No | `"v7"` | UUID version for ID: `"v7"` (time-ordered) or `"v4"` (random) |
 /// | `migrations` | No | `false` | Generate `MIGRATION_UP` and `MIGRATION_DOWN` constants |
 ///

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -30,7 +30,10 @@ default = [
   "projections",
 ]
 
-# Database dialects
+# Database dialects. Postgres is the only implemented one: selecting
+# `dialect = "clickhouse"` or `"mongodb"` on an entity is a compile
+# error pointing at the tracking issue (#23, #24). The features exist so
+# the dialect names resolve, not because they generate anything.
 postgres = ["entity-core/postgres", "entity-derive-impl/postgres"]
 clickhouse = ["entity-core/clickhouse"]
 mongodb = ["entity-core/mongodb"]

--- a/crates/entity-derive/tests/cases/fail/clickhouse_not_implemented.stderr
+++ b/crates/entity-derive/tests/cases/fail/clickhouse_not_implemented.stderr
@@ -1,4 +1,4 @@
-error: ClickHouse support is not yet implemented. Use `sql = "trait"` to generate only the trait, then implement it manually for `clickhouse::Client`.
+error: ClickHouse support is not implemented; see https://github.com/RAprogramm/entity-derive/issues/23. Use `sql = "trait"` to generate only the trait, then implement it for `clickhouse::Client`.
  --> tests/cases/fail/clickhouse_not_implemented.rs:7:10
   |
 7 | #[derive(Entity)]

--- a/crates/entity-derive/tests/cases/fail/mongodb_not_implemented.stderr
+++ b/crates/entity-derive/tests/cases/fail/mongodb_not_implemented.stderr
@@ -1,4 +1,4 @@
-error: MongoDB support is not yet implemented. Use `sql = "trait"` to generate only the trait, then implement it manually for `mongodb::Client`.
+error: MongoDB support is not implemented; see https://github.com/RAprogramm/entity-derive/issues/24. Use `sql = "trait"` to generate only the trait, then implement it for `mongodb::Client`.
  --> tests/cases/fail/mongodb_not_implemented.rs:7:10
   |
 7 | #[derive(Entity)]

--- a/wiki/Atributos.md
+++ b/wiki/Atributos.md
@@ -82,8 +82,8 @@ Dialecto de BD para generación SQL. Por defecto: `"postgres"`.
 | Dialecto | Alias | Tipo Cliente | Estado |
 |----------|-------|--------------|--------|
 | `"postgres"` | `"pg"`, `"postgresql"` | `sqlx::PgPool` | Estable |
-| `"clickhouse"` | `"ch"` | `clickhouse::Client` | Planificado |
-| `"mongodb"` | `"mongo"` | `mongodb::Client` | Planificado |
+| `"clickhouse"` | `"ch"` | `clickhouse::Client` | No implementado — error de compilación |
+| `"mongodb"` | `"mongo"` | `mongodb::Client` | No implementado — error de compilación |
 
 ### `uuid` (opcional)
 

--- a/wiki/Attributes-en.md
+++ b/wiki/Attributes-en.md
@@ -84,8 +84,8 @@ Database dialect for SQL generation. Default: `"postgres"`.
 | Dialect | Aliases | Client Type | Status |
 |---------|---------|-------------|--------|
 | `"postgres"` | `"pg"`, `"postgresql"` | `sqlx::PgPool` | Stable |
-| `"clickhouse"` | `"ch"` | `clickhouse::Client` | Planned |
-| `"mongodb"` | `"mongo"` | `mongodb::Client` | Planned |
+| `"clickhouse"` | `"ch"` | `clickhouse::Client` | Not implemented — compile error |
+| `"mongodb"` | `"mongo"` | `mongodb::Client` | Not implemented — compile error |
 
 ### `uuid` (optional)
 

--- a/wiki/Атрибуты.md
+++ b/wiki/Атрибуты.md
@@ -84,8 +84,8 @@ pub struct User { /* ... */ }
 | Диалект | Алиасы | Тип клиента | Статус |
 |---------|--------|-------------|--------|
 | `"postgres"` | `"pg"`, `"postgresql"` | `sqlx::PgPool` | Стабильно |
-| `"clickhouse"` | `"ch"` | `clickhouse::Client` | Планируется |
-| `"mongodb"` | `"mongo"` | `mongodb::Client` | Планируется |
+| `"clickhouse"` | `"ch"` | `clickhouse::Client` | Не реализовано — ошибка компиляции |
+| `"mongodb"` | `"mongo"` | `mongodb::Client` | Не реализовано — ошибка компиляции |
 
 ### `uuid` (опциональный)
 

--- a/wiki/属性.md
+++ b/wiki/属性.md
@@ -82,8 +82,8 @@ SQL生成的数据库方言。默认：`"postgres"`。
 | 方言 | 别名 | 客户端类型 | 状态 |
 |------|------|-----------|------|
 | `"postgres"` | `"pg"`, `"postgresql"` | `sqlx::PgPool` | 稳定 |
-| `"clickhouse"` | `"ch"` | `clickhouse::Client` | 计划中 |
-| `"mongodb"` | `"mongo"` | `mongodb::Client` | 计划中 |
+| `"clickhouse"` | `"ch"` | `clickhouse::Client` | 未实现 — 编译错误 |
+| `"mongodb"` | `"mongo"` | `mongodb::Client` | 未实现 — 编译错误 |
 
 ### `uuid`（可选）
 

--- a/wiki/속성.md
+++ b/wiki/속성.md
@@ -82,8 +82,8 @@ SQL 생성용 데이터베이스 방언입니다. 기본값: `"postgres"`.
 | 방언 | 별칭 | 클라이언트 타입 | 상태 |
 |------|------|----------------|------|
 | `"postgres"` | `"pg"`, `"postgresql"` | `sqlx::PgPool` | 안정 |
-| `"clickhouse"` | `"ch"` | `clickhouse::Client` | 예정 |
-| `"mongodb"` | `"mongo"` | `mongodb::Client` | 예정 |
+| `"clickhouse"` | `"ch"` | `clickhouse::Client` | 미구현 — 컴파일 오류 |
+| `"mongodb"` | `"mongo"` | `mongodb::Client` | 미구현 — 컴파일 오류 |
 
 ### `uuid` (선택)
 


### PR DESCRIPTION
Closes #244

Both dialects were listed as *planned* in the feature table and the dialect table, which reads like something a user can switch on. Selecting either one is a compile error, and migration generation for them returns nothing.

- The README feature table and the dialect table in all five wiki languages now say **not implemented — compile error**, with a link to the tracking issue.
- The crate-level attribute reference says Postgres is the only implemented dialect instead of listing three as if they were alternatives.
- The `compile_error!` messages point at #23 and #24 so a user who tries lands on the issue to follow.
- The feature declarations in `Cargo.toml` explain why the features exist at all.

No dialect is implemented here — that is #23 and #24. This is about not advertising what does not exist.