### PR TITLE
#242 test: budget the size of the generated token stream

### DIFF
--- a/crates/entity-derive-impl/src/entity.rs
+++ b/crates/entity-derive-impl/src/entity.rs
@@ -88,6 +88,20 @@ mod streams;
 mod transaction;
 mod view;
 
+// The budget only means something when every generator is compiled in;
+// with a generator switched off the stream is legitimately smaller.
+#[cfg(all(
+    test,
+    feature = "events",
+    feature = "commands",
+    feature = "hooks",
+    feature = "transactions",
+    feature = "aggregate_root",
+    feature = "migrations",
+    feature = "projections"
+))]
+mod budget_tests;
+
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{DeriveInput, parse_macro_input};
@@ -98,13 +112,24 @@ use self::parse::EntityDef;
 pub fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    match EntityDef::from_derive_input(&input) {
+    expand(&input).into()
+}
+
+/// Run the whole pipeline on a parsed item and return the tokens it
+/// produces.
+///
+/// Kept separate from [`derive`] so it stays callable outside a
+/// procedural-macro context: `proc_macro::TokenStream` only exists
+/// while the compiler is expanding, which is why the crate's own tests
+/// work with `proc_macro2` here.
+pub(crate) fn expand(input: &DeriveInput) -> proc_macro2::TokenStream {
+    match EntityDef::from_derive_input(input) {
         Ok(entity) => generate(entity),
-        Err(err) => err.write_errors().into()
+        Err(err) => err.write_errors()
     }
 }
 
-fn generate(entity: EntityDef) -> TokenStream {
+fn generate(entity: EntityDef) -> proc_macro2::TokenStream {
     let dto = dto::generate(&entity);
     let query_struct = query::generate(&entity);
     let policy = policy::generate(&entity);
@@ -185,7 +210,7 @@ fn generate(entity: EntityDef) -> TokenStream {
         #migrations
     };
 
-    expanded.into()
+    expanded
 }
 
 /// Emit a `compile_error!` if the user opted into an entity-attribute

--- a/crates/entity-derive-impl/src/entity/budget_tests.rs
+++ b/crates/entity-derive-impl/src/entity/budget_tests.rs
@@ -1,0 +1,155 @@
+// SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+// SPDX-License-Identifier: MIT
+
+//! Size budget for the generated token stream.
+//!
+//! Expansion cost is what every downstream build pays, and the token
+//! stream the generators emit is what drives it. A criterion benchmark
+//! cannot reach this code — nothing may link a proc-macro crate — so
+//! the guard is a budget instead: reference entities are expanded and
+//! the resulting token count is compared against a recorded ceiling.
+//!
+//! A failure means the generated code grew. That is not automatically
+//! wrong: a new generator legitimately emits more. Read the diff, decide
+//! whether the growth is what you intended, and raise the number in the
+//! same commit that causes it — the recorded value is a decision, not a
+//! measurement to be blessed away.
+
+use proc_macro2::{TokenStream, TokenTree};
+use syn::{DeriveInput, parse_quote};
+
+use crate::entity::expand;
+
+/// Tokens emitted for one entity definition, counted through nesting.
+///
+/// A delimited group is one tree at the top level; counting only those
+/// would report a whole function body as a single token.
+fn tokens(input: &DeriveInput) -> usize {
+    fn count(stream: TokenStream) -> usize {
+        stream
+            .into_iter()
+            .map(|tree| match tree {
+                TokenTree::Group(group) => 1 + count(group.stream()),
+                _ => 1
+            })
+            .sum()
+    }
+
+    count(expand(input))
+}
+
+/// Assert a generated stream stays within its recorded ceiling.
+///
+/// The lower bound catches the opposite failure: a generator silently
+/// dropping out (a feature gate flipped, an early return added) would
+/// otherwise pass a size check quietly.
+fn assert_within(label: &str, count: usize, ceiling: usize) {
+    let floor = ceiling / 2;
+    assert!(
+        count >= floor,
+        "{label} expanded to {count} tokens, less than half the recorded {ceiling}: a generator \
+         probably stopped emitting"
+    );
+    assert!(
+        count <= ceiling,
+        "{label} expanded to {count} tokens, above the recorded ceiling of {ceiling}: check what \
+         the change added and raise the ceiling deliberately"
+    );
+}
+
+#[test]
+fn minimal_entity_stays_small() {
+    let input: DeriveInput = parse_quote! {
+        #[entity(table = "widgets")]
+        pub struct Widget {
+            #[id]
+            pub id: uuid::Uuid,
+
+            #[field(create, update, response)]
+            pub name: String,
+        }
+    };
+
+    assert_within("minimal entity", tokens(&input), 2_800);
+}
+
+#[test]
+fn wide_entity_scales_with_columns() {
+    let input: DeriveInput = parse_quote! {
+        #[entity(table = "widgets")]
+        pub struct Widget {
+            #[id]
+            pub id: uuid::Uuid,
+
+            #[field(create, update, response)]
+            pub c1: String,
+            #[field(create, update, response)]
+            pub c2: String,
+            #[field(create, update, response)]
+            pub c3: String,
+            #[field(create, update, response)]
+            pub c4: String,
+            #[field(create, update, response)]
+            pub c5: String,
+            #[field(create, update, response)]
+            pub c6: String,
+            #[field(create, update, response)]
+            pub c7: String,
+            #[field(create, update, response)]
+            pub c8: String,
+            #[field(create, update, response)]
+            pub c9: String,
+            #[field(create, update, response)]
+            pub c10: String,
+        }
+    };
+
+    assert_within("ten-column entity", tokens(&input), 4_400);
+}
+
+#[test]
+fn fully_annotated_entity_stays_within_budget() {
+    let input: DeriveInput = parse_quote! {
+        #[entity(
+            table = "widgets",
+            migrations,
+            soft_delete,
+            transactions,
+            aggregate_root,
+            events,
+            upsert(conflict = "slug")
+        )]
+        #[projection(Card: id, name)]
+        pub struct Widget {
+            #[id]
+            pub id: uuid::Uuid,
+
+            #[field(create, update, response)]
+            #[filter(like)]
+            #[sort]
+            pub name: String,
+
+            #[field(create, response)]
+            #[column(unique)]
+            pub slug: String,
+
+            #[owner]
+            #[field(create, response)]
+            pub owner_id: uuid::Uuid,
+
+            #[version]
+            #[field(response)]
+            #[auto]
+            pub version: i32,
+
+            #[field(response)]
+            #[auto]
+            pub created_at: chrono::DateTime<chrono::Utc>,
+
+            #[field(skip)]
+            pub deleted_at: Option<chrono::DateTime<chrono::Utc>>,
+        }
+    };
+
+    assert_within("fully annotated entity", tokens(&input), 9_200);
+}


### PR DESCRIPTION
Closes #242

Expansion cost is what every downstream build pays and nothing measured it. A criterion benchmark cannot: `entity-derive-impl` is a proc-macro crate, and nothing — bench target included — may link one. What is measurable in-crate is the quantity that drives the cost, the size of the emitted token stream.

- `expand` now returns `proc_macro2` tokens, with the `proc_macro` conversion left in the derive entry point, so the pipeline is callable from the crate's own tests.
- Three reference entities — minimal, ten columns, fully annotated — are expanded and their token counts checked against recorded ceilings: 2 800, 4 400 and 9 200 against measured 2 358, 3 672 and 7 741.
- Each check has a floor as well. A generator that silently stops emitting would pass a ceiling-only test.
- The budget is gated on the full generator set, since a build with generators switched off legitimately emits less.

A failure is a prompt, not a verdict: read what the change added, and raise the ceiling in the same commit if the growth is intended.