### PR TITLE
#268 ci: publish only from the release PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,6 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
-      force_publish:
-        description: "Force publish (ignores version check)"
-        type: boolean
-        default: false
       skip_tests:
         description: "Skip test stage (for emergency releases)"
         type: boolean

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,18 @@ Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
 
 ### 3. Create PR
 
-- Title: `123`
+- Title: same format as the commit — `#123 feat: add custom class support`.
+  A squash merge takes the PR title as the commit subject, and the
+  changelog groups releases by the type in that subject; a bare number
+  lands the change in no section.
 - Description must include: `Closes #123`
+
+### 4. Bump the version only for a behavioural break
+
+Versions are otherwise raised by the release PR, never by hand. The one
+exception is a change that breaks behaviour without breaking the API —
+`cargo semver-checks` cannot see it, so the PR itself raises the version
+of the affected crates to the next minor. See [RELEASE.md](RELEASE.md).
 
 ## Before commit
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,25 +5,70 @@ SPDX-License-Identifier: MIT
 
 # Release Process
 
-Releases are fully automated by [release-plz](https://release-plz.dev).
+Releases are driven by [release-plz](https://release-plz.dev).
 
 ## Flow
 
-1. Land conventional commits on `main` (`#N feat: ...`, `#N fix: ...`).
+1. Land commits on `main` using the repository subject format
+   (`#N feat: ...`, `#N fix: ...`).
 2. The `Release-plz` workflow keeps a release PR open, bumping crate
-   versions from the commit history and prepending `CHANGELOG.md`
-   sections. Do not bump versions by hand.
+   versions and prepending `CHANGELOG.md` sections.
 3. Review and squash-merge the release PR. The workflow then publishes
    `entity-core` → `entity-derive-impl` → `entity-derive` to crates.io
    in dependency order, tags `vX.Y.Z` (facade version) and creates the
    GitHub release.
 
+Publishing has exactly one path: merging the release PR.
+`release_always = false` in `release-plz.toml` makes the `release`
+command act only on commits that belong to a `release-plz-*` branch, so
+nothing reaches crates.io without a reviewed changelog section.
+
+## Versioning policy
+
+Semantic Versioning 2.0.0 with Cargo's `0.x` interpretation:
+
+| Change | Bump while major is `0` | Bump after 1.0 |
+|---|---|---|
+| Breaking (API or behaviour) | minor | major |
+| New capability, additive | patch | minor |
+| Fix, docs, internals | patch | patch |
+
+Two mechanisms decide the number, and neither reads the commit subject:
+
+- `cargo semver-checks` runs on every PR and in release-plz. An
+  API-incompatible diff forces the breaking bump automatically.
+- A **behavioural** break — generated SQL that means something else, a
+  changed default, a stricter runtime check — is invisible to
+  `cargo semver-checks`. The PR that introduces it must raise the
+  version of the affected crates by hand, to the next minor while the
+  major is `0`. Merging that PR does not publish: the bumped,
+  unpublished version flows into the next release PR.
+
+The subject prefix (`#N feat:`) is not a conventional commit, so
+release-plz treats it as a plain message. It still selects the
+`CHANGELOG.md` section through the preprocessors in `release-plz.toml`,
+but it never decides the version on its own. Do not rely on `feat!:` to
+signal a break — bump the version instead.
+
 ## Configuration
 
 | File | Purpose |
 |------|---------|
-| `release-plz.toml` | Per-package settings, changelog headings |
+| `release-plz.toml` | Per-package settings, changelog headings, publish gating |
 | `.github/workflows/release-plz.yml` | The two-mode workflow (`release-pr` + `release`) |
 
 Secrets: `GH_TOKEN` (PAT, so the release PR triggers CI) and
 `CARGO_REGISTRY_TOKEN`.
+
+## Verifying a release
+
+Within a few minutes of the release PR merging:
+
+- <https://crates.io/crates/entity-derive> shows the new version.
+- <https://docs.rs/entity-derive> rebuilds.
+- The tag `vX.Y.Z` and a GitHub release whose body is the `CHANGELOG.md`
+  section for that version both exist.
+
+If any of these is missing, inspect the most recent `Release-plz` run on
+`main`; `release-plz release` is idempotent and can be re-run through
+the workflow's manual dispatch.

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,6 +19,15 @@ git_release_enable = false
 git_tag_enable = false
 publish = true
 release = true
+# Publish only from a release PR. Without this, `release-plz release`
+# publishes on ANY push to `main` where a Cargo.toml version is ahead of
+# crates.io — and a breaking change must raise the version inside its own
+# PR so `cargo semver-checks` can classify the API diff. Such a merge
+# would otherwise reach crates.io with no curated CHANGELOG section and
+# wrong release notes. With `release_always = false` the bumped version
+# flows into the next release PR instead, and publishing happens when
+# that PR merges.
+release_always = false
 
 [[package]]
 name = "entity-derive"


### PR DESCRIPTION
Closes #268

`release_always = false` confines `release-plz release` to commits on a `release-plz-*` branch, so a version raised inside a feature PR — which a behavioural break has to do — no longer ships to crates.io outside the curated changelog.

`RELEASE.md` gains the versioning policy: what decides the bump (`cargo semver-checks`, plus a manual bump for breaks it cannot see), why the `#N type:` subject never decides it, and how to verify a release landed. `CONTRIBUTING.md` now asks for the same subject format in the PR title — a squash merge takes it as the commit subject and the changelog groups by the type in it — and records when a contributor bumps a version by hand.

The unused `force_publish` dispatch input is gone; publishing belongs to release-plz.