### PR TITLE
#269 docs: security, support and conduct policies

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,38 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Code of Conduct
+
+## Our pledge
+
+This project welcomes contributors regardless of experience level,
+background or identity. Everyone taking part in the issue tracker, pull
+requests, discussions and the wiki is expected to keep it that way.
+
+## Expected behaviour
+
+- Be respectful and direct. Critique the code, not the person.
+- Accept review feedback and give it in the same spirit.
+- Assume good faith; ask before concluding someone acted in bad faith.
+- Keep the discussion on the technical question at hand.
+
+## Unacceptable behaviour
+
+- Harassment, insults, or personal attacks of any kind.
+- Discriminatory remarks about identity or background.
+- Publishing someone's private information without their consent.
+- Sustained disruption of discussions or review.
+
+## Enforcement
+
+Report a violation to andrey.rozanov.vl@gmail.com. Reports are handled
+privately. The maintainer may edit or remove comments, close issues and
+pull requests, or block accounts, in proportion to the violation.
+
+## Scope
+
+This applies to every project space — repository, issues, pull requests,
+discussions, wiki — and to public spaces where someone represents the
+project.

--- a/README.md
+++ b/README.md
@@ -765,3 +765,16 @@ build without the attribute — zero runtime cost.
   </a>
 </p>
 
+
+---
+
+## Project
+
+| Document | Purpose |
+|---|---|
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Branch, commit and PR conventions; local checks; the live Postgres suite |
+| [SUPPORT.md](SUPPORT.md) | Where to ask what, and what a good issue contains |
+| [SECURITY.md](SECURITY.md) | Private vulnerability reporting, supported versions, what is in scope |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Expected behaviour in project spaces |
+| [RELEASE.md](RELEASE.md) | How a release is cut and how versions are decided |
+| [STABILITY.md](STABILITY.md) | What the generated API guarantees across versions |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Security Policy
+
+## Supported versions
+
+Fixes land on the latest published minor of each crate. Older minors are
+not patched — upgrade instead.
+
+| Crate | Supported |
+|---|---|
+| `entity-derive` | 0.22.x |
+| `entity-derive-impl` | 0.20.x |
+| `entity-core` | 0.10.x |
+
+## Reporting a vulnerability
+
+**Do not open a public issue.**
+
+| Channel | Link |
+|---|---|
+| Private advisory | <https://github.com/RAprogramm/entity-derive/security/advisories/new> |
+| Email | andrey.rozanov.vl@gmail.com |
+
+Include the entity definition that reproduces the problem, the feature
+set it was built with, the generated code or SQL if you have it, and the
+impact you see.
+
+| Stage | Timeline |
+|---|---|
+| Acknowledgement | 48 hours |
+| Assessment | 7 days |
+| Fix | by severity; a patch release follows the same automated pipeline as any other release |
+
+Disclosure is coordinated: the advisory becomes public once a fixed
+version is on crates.io.
+
+## What is in scope
+
+The macro turns an entity definition into SQL, DTOs, HTTP handlers and
+migrations. In scope:
+
+- Generated SQL that interpolates a value instead of binding it, or that
+  lets a caller-supplied string change the statement's shape.
+- A filter, scope, projection or policy wrapper that returns rows it was
+  declared to exclude — soft-deleted rows, other tenants' rows, columns
+  left out of a response DTO.
+- Generated HTTP handlers that serialize more than the response DTO
+  declares, or that skip a declared guard.
+- Identifier validation that accepts a name the generated statement
+  cannot safely carry.
+- Anything in the published crates that executes code at build time
+  beyond expanding the macro.
+
+Out of scope: vulnerabilities in dependencies (report them upstream;
+`cargo deny check` runs here and tracks advisories), and misuse of the
+generated API by a consumer crate — for example passing an unvalidated
+string where the documentation requires a bound parameter.
+
+## Supply chain
+
+Releases are published only by the `Release-plz` workflow from a merged
+release PR, never from a maintainer machine. Dependencies are checked
+against the RustSec advisory database, a licence allow-list and a source
+allow-list on every pull request; see `deny.toml`.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,37 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+# Getting help
+
+Pick the channel that matches the question.
+
+| Channel | Use it for |
+|---|---|
+| [Wiki](https://github.com/RAprogramm/entity-derive/wiki) | Attributes, filtering, relations, commands, hooks, web frameworks — the task-oriented guides, in five languages. |
+| [docs.rs](https://docs.rs/entity-derive) | API reference for the generated items and the runtime traits. |
+| [`examples/`](examples) | Ten runnable crates, one per feature area. |
+| [Issues](https://github.com/RAprogramm/entity-derive/issues) | Reproducible defects and missing functionality. |
+| [`SECURITY.md`](SECURITY.md) | **Anything that could be a vulnerability.** Never a public issue. |
+
+## Before opening an issue
+
+1. Search [closed issues](https://github.com/RAprogramm/entity-derive/issues?q=is%3Aissue+is%3Aclosed) — the answer is often there.
+2. Reproduce against the latest published version (`cargo update`).
+3. Reduce to a minimal entity definition, and say which features were
+   enabled — most reports turn on a feature gate.
+4. For a code-generation problem, include the expansion
+   (`cargo expand`) or the generated SQL, not only the compiler error.
+
+## Response time
+
+The project is maintained on a best-effort basis; expect a first
+response within a week. Security reports take priority through the
+channel in `SECURITY.md`.
+
+## Contributing a fix
+
+[`CONTRIBUTING.md`](CONTRIBUTING.md) has the branch, commit and review
+conventions, the local check commands and how to run the live Postgres
+suite.


### PR DESCRIPTION
Closes #269

`SECURITY.md` states which minors are patched, gives the private advisory and email channels with a response timeline, and — the part a generic template lacks — defines scope for a code generator: interpolated instead of bound values, a filter or policy wrapper returning rows it was declared to exclude, handlers serializing past the response DTO, identifier validation accepting a name the statement cannot carry.

`SUPPORT.md` routes questions to the wiki, docs.rs, the examples or the issue tracker, and asks a reporter for the expansion and the enabled features — the two things every code-generation report needs.

`CODE_OF_CONDUCT.md` states expected behaviour and the private enforcement channel.

README gains a table linking these together with the existing contribution, release and stability documents.