### PR TITLE
#272 ci: scheduled dependency policy and scorecard runs

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+name: Scheduled Audit
+
+# The CI workflow runs `cargo deny check` on pushes and pull requests, so
+# a quiet week leaves the tree unchecked while the advisory database keeps
+# moving. This job re-runs the same policy against `main` every Monday and
+# files an issue when it fails, because nobody watches a cron run.
+on:
+  schedule:
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  policy:
+    name: Dependency policy
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Install cargo-deny
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: cargo-deny
+
+      # Advisories move without the tree changing, and the licence, ban
+      # and source rules are policy too — run all of them, exactly as CI
+      # does on a pull request.
+      - name: Dependency policy
+        id: policy
+        run: |
+          set -o pipefail
+          cargo deny check 2>&1 | tee deny.log
+
+      - name: File an issue on failure
+        if: failure() && steps.policy.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Scheduled dependency policy check failed"
+          existing=$(gh issue list --state open --search "$title in:title" \
+            --json number --jq 'first(.[].number) // empty')
+          body=$(printf '%s\n\n```\n%s\n```\n' \
+            "\`cargo deny check\` failed on \`main\` in the scheduled run: $RUN_URL" \
+            "$(tail -n 60 deny.log)")
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "$body"
+          else
+            gh issue create --title "$title" --label security --body "$body"
+          fi

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+name: Scorecard
+
+# OpenSSF Scorecard rates supply-chain posture — branch protection, code
+# review, pinned dependencies, token permissions, signed releases. The
+# weekly run keeps the published score tied to the current `main`; the
+# push run refreshes it right after a change lands.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 4 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: read-all
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: scorecard-results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF artefact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: scorecard-results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        with:
+          sarif_file: scorecard-results.sarif


### PR DESCRIPTION
Closes #272

The advisory database moves while the tree stands still, and nothing here had a schedule — a RUSTSEC entry against a dependency went unreported until the next pull request. `Scheduled Audit` re-runs the full `cargo deny check` against `main` every Monday, and because a cron failure has no reviewer, it files an issue with the tail of the output, commenting on the existing one instead of opening duplicates.

`Scorecard` publishes the OpenSSF supply-chain rating weekly and after each push to `main`, uploading SARIF to code scanning.

Both workflows pin every action to a commit SHA and check out without persisted credentials.