### PR TITLE
#270 ci: release provenance and a yank workflow

### DIFF
--- a/.github/workflows/release-attestations.yml
+++ b/.github/workflows/release-attestations.yml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+# A published release carries three crates. This job repackages them from
+# the tagged commit, generates a CycloneDX SBOM, signs a SLSA build
+# provenance attestation through Sigstore, and attaches everything to the
+# GitHub release — so a consumer can run `gh attestation verify` against
+# the `.crate` file they downloaded and see it was built here, by this
+# workflow, from this tag.
+
+name: Release attestations
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to re-attest (e.g. v0.22.7)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  attest:
+    name: Generate SBOM and provenance
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: ${{ github.repository_owner == 'RAprogramm' }}
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout tagged commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      # `--no-verify` skips the compile step: the artefacts published to
+      # crates.io were already verified by release-plz, and this job only
+      # has to reproduce the byte content of those archives.
+      - name: Package the workspace
+        run: cargo package --workspace --no-verify
+
+      - name: Collect the .crate archives
+        id: artefacts
+        run: |
+          set -euo pipefail
+          mapfile -t crates < <(find target/package -maxdepth 1 -name '*.crate' | sort)
+          if [ "${#crates[@]}" -eq 0 ]; then
+            echo "::error::No .crate archives under target/package" >&2
+            exit 1
+          fi
+          printf 'Packaged %d archives\n' "${#crates[@]}"
+          {
+            echo 'paths<<EOF'
+            printf '%s\n' "${crates[@]}"
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Generate CycloneDX SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          path: ./
+          format: cyclonedx-json
+          output-file: entity-derive-sbom.cdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Generate build provenance attestation
+        id: attest
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: |
+            ${{ steps.artefacts.outputs.paths }}
+            entity-derive-sbom.cdx.json
+
+      - name: Attach artefacts to the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          BUNDLE: ${{ steps.attest.outputs.bundle-path }}
+          PATHS: ${{ steps.artefacts.outputs.paths }}
+        run: |
+          set -euo pipefail
+          cp "$BUNDLE" entity-derive-provenance.sigstore.json
+          mapfile -t crates <<< "$PATHS"
+          gh release upload "$TAG" \
+            entity-derive-sbom.cdx.json \
+            entity-derive-provenance.sigstore.json \
+            "${crates[@]}" \
+            --clobber

--- a/.github/workflows/yank.yml
+++ b/.github/workflows/yank.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+# Withdraw a published version without a maintainer machine and without a
+# local registry token. Yanking keeps the version resolvable for existing
+# lockfiles but stops new dependants from selecting it — the response to a
+# release that shipped broken or incomplete contents. The three crates
+# version independently, so the crate is an explicit choice.
+
+name: Yank
+
+on:
+  workflow_dispatch:
+    inputs:
+      crate:
+        description: Crate to act on
+        required: true
+        type: choice
+        options:
+          - entity-derive
+          - entity-derive-impl
+          - entity-core
+      version:
+        description: "Version, e.g. 0.22.6"
+        required: true
+        type: string
+      undo:
+        description: Un-yank instead of yank
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.crate }}-${{ inputs.version }}
+  cancel-in-progress: false
+
+jobs:
+  yank:
+    name: Yank
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: ${{ github.repository_owner == 'RAprogramm' }}
+    steps:
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Yank or un-yank
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CRATE: ${{ inputs.crate }}
+          VERSION: ${{ inputs.version }}
+          UNDO: ${{ inputs.undo }}
+        run: |
+          set -euo pipefail
+          if [ "$UNDO" = "true" ]; then
+            echo "Un-yanking $CRATE@$VERSION"
+            cargo yank --undo --version "$VERSION" "$CRATE"
+          else
+            echo "Yanking $CRATE@$VERSION"
+            cargo yank --version "$VERSION" "$CRATE"
+          fi

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -60,6 +60,33 @@ signal a break — bump the version instead.
 Secrets: `GH_TOKEN` (PAT, so the release PR triggers CI) and
 `CARGO_REGISTRY_TOKEN`.
 
+## Supply-chain artefacts
+
+Publishing a GitHub release triggers `release-attestations.yml`, which
+repackages the workspace from the tagged commit and attaches to the
+release:
+
+| Artefact | What it is |
+|---|---|
+| `entity-{core,derive-impl,derive}-X.Y.Z.crate` | The archives, byte-identical to the ones on crates.io |
+| `entity-derive-sbom.cdx.json` | CycloneDX bill of materials for the workspace |
+| `entity-derive-provenance.sigstore.json` | Sigstore bundle covering every artefact above |
+
+A consumer verifies an archive against the provenance without trusting
+this repository's word for it:
+
+```bash
+gh attestation verify entity-derive-0.22.7.crate --repo RAprogramm/entity-derive
+```
+
+## Withdrawing a release
+
+Run the `Yank` workflow with the crate, the version, and optionally the
+un-yank flag. It uses the same registry token as publishing, so nothing
+has to happen on a maintainer machine. Yanking keeps the version
+resolvable for existing lockfiles and stops new dependants from selecting
+it; record the reason in the next `CHANGELOG.md` section.
+
 ## Verifying a release
 
 Within a few minutes of the release PR merging:


### PR DESCRIPTION
Closes #270

Publishing a release now triggers a job that repackages the workspace from the tagged commit, generates a CycloneDX SBOM, signs a SLSA build-provenance attestation through Sigstore, and attaches the three `.crate` archives, the SBOM and the Sigstore bundle to the release. A consumer can then run `gh attestation verify` on an archive and see it was built from this tag by this workflow, instead of taking the registry's word for it.

Withdrawing a release no longer needs a maintainer machine or a local registry token: the `Yank` workflow takes the crate, the version and an un-yank flag, and uses the same token the release pipeline holds. The three crates version independently, so the crate is an explicit choice rather than a guess.

`RELEASE.md` documents both, including the verification command.