### PR TITLE
#279 docs: issue, pull-request and ownership templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# Every path has one owner today; the file exists so review routing and
+# protection rules have something to resolve against.
+*                           @RAprogramm
+
+/crates/entity-core/        @RAprogramm
+/crates/entity-derive-impl/ @RAprogramm
+/crates/entity-derive/      @RAprogramm
+/examples/                  @RAprogramm
+/wiki/                      @RAprogramm
+/site/                      @RAprogramm
+
+/.github/                   @RAprogramm
+/release-plz.toml           @RAprogramm
+/deny.toml                  @RAprogramm
+/Cargo.toml                 @RAprogramm
+/Cargo.lock                 @RAprogramm

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Bug report
+description: Something the macro generates, or the runtime does, is wrong
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A possible vulnerability goes to
+        [SECURITY.md](https://github.com/RAprogramm/entity-derive/blob/main/SECURITY.md),
+        never here.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: What happens
+      description: The behaviour you see, and the behaviour you expected instead.
+    validations:
+      required: true
+
+  - type: textarea
+    id: entity
+    attributes:
+      label: Entity definition
+      description: The smallest `#[derive(Entity)]` definition that reproduces it.
+      render: rust
+    validations:
+      required: true
+
+  - type: input
+    id: features
+    attributes:
+      label: Features
+      description: The features enabled on `entity-derive`; `default` if untouched.
+      placeholder: "postgres, api, migrations"
+    validations:
+      required: true
+
+  - type: textarea
+    id: output
+    attributes:
+      label: Compiler error, expansion or generated SQL
+      description: >
+        For a compile failure, the full error. For wrong output, the
+        relevant part of `cargo expand` or the statement the database
+        received.
+      render: text
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: entity-derive version
+      placeholder: "0.22.6"
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Rust and Postgres versions
+      placeholder: "rustc 1.96.0, Postgres 18"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+blank_issues_enabled: false
+contact_links:
+  - name: Guides
+    url: https://github.com/RAprogramm/entity-derive/wiki
+    about: Attributes, filtering, relations, commands and hooks, in five languages
+  - name: API reference
+    url: https://docs.rs/entity-derive
+    about: Rustdoc for the generated items and the runtime traits
+  - name: Vulnerability report
+    url: https://github.com/RAprogramm/entity-derive/security/advisories/new
+    about: Never open a public issue for a security problem

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+name: Feature request
+description: Generated code you need and the macro does not produce
+labels: ["enhancement"]
+
+body:
+  - type: textarea
+    id: missing
+    attributes:
+      label: What is missing
+      description: The generated item, attribute or SQL that does not exist today.
+    validations:
+      required: true
+
+  - type: textarea
+    id: declaration
+    attributes:
+      label: How you would declare it
+      description: The attribute or entity definition you would write.
+      render: rust
+    validations:
+      required: true
+
+  - type: textarea
+    id: generated
+    attributes:
+      label: What it should generate
+      description: The method signature, statement or type you expect out of it.
+      render: rust
+    validations:
+      required: false
+
+  - type: textarea
+    id: workaround
+    attributes:
+      label: What you write instead today
+      description: The hand-written code this would replace.
+      render: rust
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+SPDX-License-Identifier: MIT
+-->
+
+Closes #
+
+## What changes
+
+<!-- What the generated code, SQL or API does now that it did not before. -->
+
+## Checks
+
+- [ ] `cargo +nightly fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`
+- [ ] Tests cover the change; a generated-SQL change is executed against Postgres
+- [ ] README, rustdoc, examples and wiki updated in this PR
+- [ ] Version untouched — unless this breaks behaviour without breaking the API, see [RELEASE.md](../blob/main/RELEASE.md)

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# The intended state of the repository's settings, in the tree rather
+# than only in the web UI. Applied automatically when the Repository
+# Settings app (https://github.com/apps/settings) is installed; read as
+# the reference otherwise. Branch protection here mirrors what is
+# configured on `main`.
+
+repository:
+  name: entity-derive
+  description: Derive macro that generates DTOs, repositories, SQL queries, REST handlers, and OpenAPI docs from a single Rust struct definition
+  homepage: https://raprogramm.github.io/entity-derive/
+  topics: rust, proc-macro, derive-macro, code-generation, orm, sqlx, postgresql, database, crud, dto, repository-pattern, rest-api, openapi, axum, utoipa, boilerplate
+  default_branch: main
+  has_issues: true
+  has_projects: false
+  has_wiki: true
+  has_discussions: false
+  allow_squash_merge: true
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_update_branch: true
+  delete_branch_on_merge: true
+  # A squash merge takes the pull-request title as the subject, which is
+  # what the changelog groups releases by.
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+
+branches:
+  - name: main
+    protection:
+      required_status_checks:
+        strict: true
+        contexts:
+          - CI Success
+      required_linear_history: true
+      allow_force_pushes: false
+      allow_deletions: false
+      required_conversation_resolution: true
+      # Single-maintainer repository: requiring an approving review would
+      # deadlock every pull request. The gate is the CI check above.
+      required_pull_request_reviews: null
+      enforce_admins: false
+      restrictions: null
+
+labels:
+  - name: bug
+    color: d73a4a
+    description: Generated code or runtime behaviour is wrong
+  - name: enhancement
+    color: a2eeef
+    description: New generated capability
+  - name: documentation
+    color: 0075ca
+    description: README, rustdoc, examples or wiki
+  - name: security
+    color: d93f0b
+    description: Supply chain and vulnerability handling
+  - name: dependencies
+    color: 0366d6
+    description: Dependency updates
+  - name: rust
+    color: dea584
+    description: Rust code


### PR DESCRIPTION
Closes #279

Bug reports now ask for the four things a code-generation report is useless without: the entity definition, the enabled features, the expansion or generated SQL, and the version. Feature requests ask how the attribute would be declared and what it should generate. Blank issues are off and the chooser links the wiki, docs.rs and the private advisory form — the last so a vulnerability never lands in a public issue.

The pull-request template carries the checks a reviewer would otherwise ask for, including that a generated-SQL change is executed against Postgres and that the version stays untouched unless the change breaks behaviour without breaking the API.

`CODEOWNERS` gives every path an owner, and `.github/settings.yml` records the intended repository settings and branch protection in the tree instead of only in the web UI.