### PR TITLE
#281 ci: mutation testing nightly and per pull request

### DIFF
--- a/.cargo/mutants.toml
+++ b/.cargo/mutants.toml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+# SPDX-License-Identifier: MIT
+
+# The suite runs under nextest with every feature on, minus the
+# live-Postgres binary: that one needs a server and skips without it, so
+# a mutant it would have caught would look survived.
+test_tool = "nextest"
+additional_cargo_test_args = ["--all-features", "-E", "not binary(postgres)"]
+
+# The generators are what mutation testing judges; fixtures and examples
+# are not under test themselves.
+exclude_globs = [
+    "crates/*/tests/**",
+    "examples/**",
+]
+
+# Expanding a macro and compiling the result costs more than a unit test,
+# so a mutant needs headroom before it counts as a timeout.
+timeout_multiplier = 3.0
+minimum_test_timeout = 120

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2025-2026 RAprogramm <andrey.rozanov.vl@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
+name: Mutants
+
+# Coverage says a line ran; mutation testing says a change to that line
+# was noticed. For a code generator the difference is wide — a test can
+# expand a macro, assert little, and still count as coverage. cargo-mutants
+# rewrites one expression at a time and reports the mutants the suite let
+# through.
+#
+# The full sweep is nightly: ~1200 mutants at a few seconds each is too
+# long for the pull-request path. Pull requests get the mutants that touch
+# their own diff instead, which is fast and is where the signal matters.
+# Both are advisory — a surviving mutant is a question for review, not a
+# merge blocker.
+on:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  full:
+    name: Full sweep
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    if: ${{ github.event_name != 'pull_request' }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: mutants
+          save-if: ${{ github.event_name == 'schedule' }}
+
+      - name: Install tools
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: cargo-mutants,cargo-nextest
+
+      - name: Run cargo-mutants
+        continue-on-error: true
+        run: cargo mutants --no-shuffle --jobs 2 --output mutants.out
+
+      - name: Summarize outcomes
+        if: always()
+        run: |
+          set -euo pipefail
+          outcomes=mutants.out/outcomes.json
+          if [ ! -f "$outcomes" ]; then
+            echo "No outcomes.json produced" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Mutation testing"
+            echo
+            echo "| Outcome | Count |"
+            echo "|---|---:|"
+            jq -r '[.outcomes[] | select(.scenario | type == "object") | .summary] | group_by(.) | map("| \(.[0]) | \(length) |") | .[]' "$outcomes"
+            echo
+            missed=$(jq -r '.outcomes[] | select(.summary == "MissedMutant") | .scenario.Mutant | "\(.file):\(.function.span.start.line) \(.function.function_name)"' "$outcomes" || true)
+            if [ -n "$missed" ]; then
+              echo "### Survived"
+              echo
+              echo '```'
+              echo "$missed"
+              echo '```'
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutants-full
+          path: mutants.out/
+          retention-days: 30
+
+  diff:
+    name: Pull-request diff
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    if: ${{ github.event_name == 'pull_request' }}
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@2c7215f132e9ebf062739d9130488b56d53c060c # master
+        with:
+          toolchain: stable
+
+      - name: Cache
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: mutants
+          save-if: false
+
+      - name: Install tools
+        uses: taiki-e/install-action@41049aa56687c35e0afa74eed4f09cec4f9afabf # v2.85.2
+        with:
+          tool: cargo-mutants,cargo-nextest
+
+      - name: Compute the diff
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git diff "$BASE_SHA"...HEAD > pr.diff
+
+      - name: Run cargo-mutants on the diff
+        run: cargo mutants --no-shuffle --jobs 2 --in-diff pr.diff --output mutants.out
+
+      - name: Summarize outcomes
+        if: always()
+        run: |
+          set -euo pipefail
+          outcomes=mutants.out/outcomes.json
+          if [ ! -f "$outcomes" ]; then
+            echo "No mutants in this diff" >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          {
+            echo "## Mutation testing (diff)"
+            echo
+            echo "| Outcome | Count |"
+            echo "|---|---:|"
+            jq -r '[.outcomes[] | select(.scenario | type == "object") | .summary] | group_by(.) | map("| \(.[0]) | \(length) |") | .[]' "$outcomes"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: mutants-diff
+          path: mutants.out/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target
 Cargo.lock
 examples/**/target/
+
+# cargo-mutants reports
+mutants.out*/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ run drops it once it is half an hour old.
 | Workflow audit | `zizmor --offline .github/workflows/` — actions must be pinned to a commit SHA |
 | Semver | `cargo semver-checks check-release --workspace --exclude entity-derive-impl` |
 | Coverage | `cargo llvm-cov` (95%+ required) |
+| Mutants (advisory) | `cargo mutants --in-diff <(git diff main...HEAD)` — nightly runs the full sweep |
 
 ## Code standards
 


### PR DESCRIPTION
Closes #281

Coverage is gated at 95%, which counts executed lines. For a code generator that is weak evidence: a test can expand a macro, assert little and still register as covered. cargo-mutants rewrites one expression at a time and reports which mutants the suite let through — 1184 of them in this workspace.

The full sweep runs nightly and reports the outcome counts plus every survivor, file and function, as a job summary and a 30-day artefact. Pull requests run only the mutants their own diff touches, which is fast enough to sit in the review loop. Both are advisory: a survivor is a question for review, not a merge blocker.

`.cargo/mutants.toml` pins the suite it runs — nextest, all features, without the live-Postgres binary. That binary skips itself when no server is configured, so including it would let mutants look survived that nothing ever tried to catch.