### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/RAprogramm/entity-derive/compare/v0.22.0...HEAD)
 
+## [0.22.8](https://github.com/RAprogramm/entity-derive/compare/v0.22.7...v0.22.8) - 2026-07-27
+
+### ✨ Features
+
+- domain operations on the transaction adapter ([#295](https://github.com/RAprogramm/entity-derive/issues/295))
+
 ## [0.22.7](https://github.com/RAprogramm/entity-derive/compare/v0.22.6...v0.22.7) - 2026-07-27
 
 ### ✨ Features

--- a/crates/entity-derive-impl/CHANGELOG.md
+++ b/crates/entity-derive-impl/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.17](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.16...entity-derive-impl-v0.20.17) - 2026-07-27
+
+### ✨ Features
+
+- domain operations on the transaction adapter ([#295](https://github.com/RAprogramm/entity-derive/issues/295))
+
 ## [0.20.16](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.15...entity-derive-impl-v0.20.16) - 2026-07-27
 
 ### ⚙️ CI

--- a/crates/entity-derive-impl/Cargo.toml
+++ b/crates/entity-derive-impl/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive-impl"
-version = "0.20.16"
+version = "0.20.17"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/entity-derive/Cargo.toml
+++ b/crates/entity-derive/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "entity-derive"
-version = "0.22.7"
+version = "0.22.8"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `entity-derive-impl`: 0.20.16 -> 0.20.17
* `entity-derive`: 0.22.7 -> 0.22.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `entity-derive-impl`

<blockquote>

## [0.20.17](https://github.com/RAprogramm/entity-derive/compare/entity-derive-impl-v0.20.16...entity-derive-impl-v0.20.17) - 2026-07-27

### ✨ Features

- domain operations on the transaction adapter ([#295](https://github.com/RAprogramm/entity-derive/issues/295))
</blockquote>

## `entity-derive`

<blockquote>


## [0.22.8](https://github.com/RAprogramm/entity-derive/compare/v0.22.7...v0.22.8) - 2026-07-27

### ✨ Features

- domain operations on the transaction adapter ([#295](https://github.com/RAprogramm/entity-derive/issues/295))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).