### PR TITLE
#297 ci: decline the syn 3 update until darling supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,13 @@ updates:
     reviewers:
       - "RAprogramm"
     open-pull-requests-limit: 10
+    # `syn` 3 cannot be taken while attribute parsing goes through
+    # darling, whose releases still require `syn` 2 — the two majors do
+    # not coexist in one tree. Upstream tracks the port in darling#431;
+    # drop this entry once a darling release depends on `syn` 3.
+    ignore:
+      - dependency-name: "syn"
+        versions: ["3.x"]
     groups:
       # Group all minor and patch updates together
       rust-dependencies:


### PR DESCRIPTION
Closes #297

The proc-macro group update to `syn` 3 has been open and red since 20 July and cannot be made green here: attribute parsing goes through darling, whose latest release still requires `syn` 2, and two majors of the parser cannot coexist in one tree. Upstream tracks the port in darling#431, unreleased.

The update is declined in the dependabot configuration with the reason and the condition for removing the rule. Dependabot closes the standing pull request on its next run.